### PR TITLE
Introducing generic constraints

### DIFF
--- a/theories/adequacy.v
+++ b/theories/adequacy.v
@@ -991,6 +991,7 @@ Definition main_le := {|
 Definition main_cdef tag methods := {|
   classname := tag;
   generics := [];
+  constraints := [];
   superclass := None;
   classfields := ∅;
   classmethods := methods;

--- a/theories/adequacy.v
+++ b/theories/adequacy.v
@@ -41,21 +41,24 @@ Section proofs.
     ∃ (iFs : gmapO string (laterO (sem_typeO Σ))),
     sh !! ℓ ≡ Some (t, iFs) ∗ heap_models_fields iFs vs.
 
-  Lemma expr_adequacy (σi:interp_env) e lty le ty val :
+  Lemma expr_adequacy Σc Σi e lty le ty val :
     map_Forall (λ _cname, wf_cdef_fields) Δ →
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _ : string, wf_cdef_mono) Δ →
+    Σinterp Σc Σi →
+    interp_env_as_mixed Σc Σi →
+    Forall wf_constraint Σc →
     wf_lty lty →
     expr_eval le e = Some val →
-    expr_has_ty [] lty e ty →
-    interp_local_tys σi lty le -∗
-    interp_type ty σi val.
+    expr_has_ty Σc lty e ty →
+    interp_local_tys Σc Σi  lty le -∗
+    interp_type Σc Σi ty val.
   Proof.
-    move => ????? he h; move: le val he.
+    move => ???????? he h; move: le val he.
     elim: h => [z | b | | op e1 e2 hop he1 hi1 he2 hi2 |
         op e1 e2 hop he1 hi1 he2 hi2 |
-        v vty hv | | exp S T hS hi hwf hsub ] => le val he; iIntros "#Hlty".
+        v vty hv | | exp S T hS hi hwf hok hsub ] => le val he; iIntros "#Hlty".
     - inv he; rewrite interp_type_unfold /=; by eauto.
     - inv he; rewrite interp_type_unfold /=; by eauto.
     - inv he; rewrite interp_type_unfold /=; by eauto.
@@ -105,10 +108,10 @@ Section proofs.
       + by iApply he.
   Qed.
 
-  Lemma interp_local_tys_update σi v lty le ty val :
-    interp_local_tys σi lty le -∗
-    interp_type ty σi val -∗
-    interp_local_tys σi (<[v:=ty]>lty) (<[v:=val]>le).
+  Lemma interp_local_tys_update Σc Σi v lty le ty val :
+    interp_local_tys Σc Σi lty le -∗
+    interp_type Σc Σi ty val -∗
+    interp_local_tys Σc Σi (<[v:=ty]>lty) (<[v:=val]>le).
   Proof.
     iIntros "#[Hthis Hi] #?".
     iSplit; first done.
@@ -119,24 +122,27 @@ Section proofs.
     - rewrite lookup_insert_ne; last done. by iApply "Hi".
   Qed.
 
-  Lemma interp_local_tys_list (σi:interp_env) lty le targs args vargs l t σ:
+  Lemma interp_local_tys_list Σc Σi lty le targs args vargs l t σ:
     map_Forall (λ _cname, wf_cdef_fields) Δ →
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _ : string, wf_cdef_mono) Δ →
+    Σinterp Σc Σi →
+    interp_env_as_mixed Σc Σi →
+    Forall wf_constraint Σc →
     wf_lty lty →
     dom stringset targs = dom stringset args →
     map_args (expr_eval le) args = Some vargs →
     (∀ (x : string) (ty : lang_ty) (arg : expr),
     targs !! x = Some ty →
     args !! x = Some arg →
-    expr_has_ty [] lty arg ty) →
-    interp_class_strict t σ σi interp_type (LocV l) -∗
-    interp_local_tys σi lty le -∗
-    interp_local_tys σi {| type_of_this := (t, σ); ctxt := targs |}
-                        {| vthis := l; lenv := vargs |}.
+    expr_has_ty Σc lty arg ty) →
+    interp_class_strict Σc t σ (interp_type Σc Σi) (LocV l) -∗
+    interp_local_tys Σc Σi lty le -∗
+    interp_local_tys Σc Σi {| type_of_this := (t, σ); ctxt := targs |}
+                           {| vthis := l; lenv := vargs |}.
   Proof.
-    move => ????? hdom hargs helt.
+    move => ???????? hdom hargs helt.
     iIntros "#Hl #[Hthis Hle]".
     iSplit; first done.
     iIntros (v ty) "%hin".
@@ -162,50 +168,55 @@ Section proofs.
     by iSplit.
   Qed.
 
-  Lemma heap_models_update h l rt vs (σi: interp_env) t σt f vis fty orig v:
+  Lemma heap_models_update Σc Σi h l rt vs t σt f vis fty orig v:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_fields) Δ →
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     map_Forall (λ _ : string, wf_cdef_fields_wf) Δ →
     map_Forall (λ _cname, wf_field_mono) Δ →
     map_Forall (λ _ : string, wf_cdef_mono) Δ →
+    Σinterp Σc Σi →
+    interp_env_as_mixed Σc Σi →
+    Forall wf_constraint Σc →
     h !! l = Some (rt, vs) →
     has_field f t vis fty orig →
     wf_ty (ClassT t σt) →
     match vis with
-    | Public => interp_type (ClassT t σt) σi (LocV l)
-    | Private => interp_class_strict t σt σi interp_type (LocV l)
+    | Public => interp_type Σc Σi (ClassT t σt) (LocV l)
+    | Private => interp_class_strict Σc t σt (interp_type Σc Σi) (LocV l)
     end -∗
-    interp_type (subst_ty σt fty) σi v -∗
+    interp_type Σc Σi (subst_ty σt fty) v -∗
     heap_models h -∗
     heap_models (<[l:=(rt, <[f:=v]> vs)]> h).
   Proof.
-    move => ?? hfb ??? hheap hfield hwf.
+    move => ???? hfb ???? hheap hfield hwf.
     iIntros "hrecv".
     iAssert (∃ t' def σ' σt' fields ifields,
       ⌜inherits_using t' t σ' ∧
        wf_ty (ClassT t' σt') ∧
        Δ !! t = Some def ∧
        match vis with
-       | Public => [] ⊢ subst_ty σt' <$> σ' <: generics def :> σt
+       | Public => Σc ⊢ subst_ty σt' <$> σ' <: generics def :> σt
        | Private => subst_ty σt' <$> σ' = σt
        end ∧ has_fields t' fields⌝ ∗
-      interp_fields σi t' σt' (dom _ fields) ifields interp_type ∗
+      interp_fields t' σt' (dom _ fields) ifields (interp_type Σc Σi) ∗
       l↦(t',ifields))%I with "[hrecv]" as "hrecv".
     { destruct vis.
       - rewrite interp_class_unfold.
         iDestruct "hrecv" as (l' t' def σ' σt' fields ifields) "[%H [hsem hl]]".
-        destruct H as [[= <-] [ hinherits' [hwfσ' [hdef [hσ' hfields]]]]].
+        destruct H as ([= <-] & H).
+        repeat destruct H as [? H].
         iExists _, _, _, _ ,_ ,_.
         by repeat iSplit => //.
       - iDestruct "hrecv" as (l' t' σ' σt' fields ifields) "[%H [hsem hl]]".
-        destruct H as [[= <-] [ hinherits' [hwfσ' [hσ' hfields]]]].
+        destruct H as ([= <-] & H).
+        repeat destruct H as [? H].
         inv hwf.
-        iExists _, _, _, _ ,_ ,_.
+        iExists _, _, _ ,_ ,_, _.
         by repeat iSplit => //.
     }
-    iDestruct "hrecv" as (t' def σ' σt' fields ifields) "[%H [hsem hl]]".
-    destruct H as [hinherits' [hwfσ' [hdef [hσ' hfields]]]].
+    iDestruct "hrecv" as (t' def σ' σt' fields ifields) "[%hpure [hsem hl]]".
+    destruct hpure as (hinherits' & hwfσ' & hdef & hσ' & hfields).
     iIntros "#hv hmodels".
     iDestruct "hmodels" as (sh) "[hown [%hdom #h]]".
     iExists sh.
@@ -263,7 +274,7 @@ Section proofs.
       simplify_eq.
       by rewrite hL.
     }
-    assert (hsub : [] ⊢ subst_ty σt fty <: subst_ty (subst_ty σt' <$> σ') fty).
+    assert (hsub : Σc ⊢ subst_ty σt fty <: subst_ty (subst_ty σt' <$> σ') fty).
     { destruct vis.
       - (* Public field access *)
         assert (hfwf := hfield).
@@ -286,25 +297,28 @@ Section proofs.
     by apply wf_ty_class_inv in hwf.
   Qed.
 
-  (*TODO things break from here *)
-  Lemma cmd_adequacy_ lty cmd lty' :
+  Lemma cmd_adequacy_ Σc lty cmd lty' :
     wf_cdefs Δ →
     wf_lty lty →
-    ⌜cmd_has_ty [] lty cmd lty'⌝ -∗
-    ∀ (σi: interp_env) st st' n, ⌜cmd_eval st cmd st' n⌝ -∗
-    heap_models st.2 ∗ interp_local_tys σi lty st.1 -∗ |=▷^n
-        heap_models st'.2 ∗ interp_local_tys σi lty' st'.1.
+    Forall wf_constraint Σc →
+    ⌜cmd_has_ty Σc lty cmd lty'⌝ -∗
+    ∀ Σi st st' n,
+    ⌜interp_env_as_mixed Σc Σi⌝ →
+    ⌜Σinterp Σc Σi⌝ →
+    ⌜cmd_eval st cmd st' n⌝ -∗
+    heap_models st.2 ∗ interp_local_tys Σc Σi lty st.1 -∗ |=▷^n
+        heap_models st'.2 ∗ interp_local_tys Σc Σi lty' st'.1.
   Proof.
-    move => wfΔ wflty.
-    iLöb as "IH" forall (lty cmd lty' wflty).
-    iIntros "%hty" (σi st st' n) "%hc".
+    move => wfΔ wflty hΣc .
+    iLöb as "IH" forall (Σc lty cmd lty' wflty hΣc).
+    iIntros "%hty" (Σi st st' n hΣi hΣcΣi) "%hc".
     iInduction hty as [ lty | lty1 lty2 lty3 fstc sndc hfst hi1 hsnd hi2 |
         lty lhs e ty he | lty1 lty2 cond thn els hcond hthn hi1 hels hi2 |
         lty lhs t targs name fty hrecv hf |
         lty lhs recv t targs name fty orig hrecv hf |
         lty fld rhs fty t σ hrecv hrhs hf |
         lty recv fld rhs fty orig t σ hrecv hrhs hf |
-        lty lhs t targs args fields hwf hf hdom harg |
+        lty lhs t targs args fields hwf hok hf hdom harg |
         lty lhs recv t targs name orig mdef args hrecv hhasm hdom hi |
         lty c rty' rty hsub h hi |
         lty rty v tv t cmd hv hr h hi
@@ -344,8 +358,8 @@ Section proofs.
       iDestruct "Hle" as "[Hthis Hle]".
       rewrite /this_type /=.
       iDestruct "Hthis" as (??????) "[%H [#Hifields H◯]]".
-      destruct H as [[= <-] [hinherits [hwfσt [htargs hfields]]]].
-      iAssert (⌜t0 = t1⌝ ∗ heap_models h ∗ ▷ interp_type (subst_ty targs fty) σi v)%I with "[Hh]" as "[%Ht [Hh Hv]]".
+      destruct H as ([= <-] & hinherits & hwfσt & hokσt & htargs & hfields).
+      iAssert (⌜t0 = t1⌝ ∗ heap_models h ∗ ▷ interp_type Σc Σi (subst_ty targs fty) v)%I with "[Hh]" as "[%Ht [Hh Hv]]".
       { iDestruct "Hh" as (sh) "(H● & %hdom & #Hh)".
         iDestruct (sem_heap_own_valid_2 with "H● H◯") as "#HΦ".
         iDestruct ("Hh" with "[//]") as (iFs) "[H H▷]".
@@ -388,8 +402,8 @@ Section proofs.
       iDestruct (expr_adequacy with "Hle") as "#He" => //; try (by apply wfΔ).
       rewrite interp_class_unfold /=.
       iDestruct "He" as (???????) "[%H [#Hifields H◯]]".
-      destruct H as [[= <-] [hinherits [hwfσt [hdef [htargs hfields]]]]].
-      iAssert (⌜t0 = t1⌝ ∗ heap_models h ∗ ▷ interp_type (subst_ty (subst_ty σt <$> σ)  fty) σi v)%I with "[Hh]" as "[%Ht [Hh Hv]]".
+      destruct H as ([= <-] & hinherits & hwfσt & hokσt & hdef & htargs & hfields).
+      iAssert (⌜t0 = t1⌝ ∗ heap_models h ∗ ▷ interp_type Σc Σi (subst_ty (subst_ty σt <$> σ)  fty) v)%I with "[Hh]" as "[%Ht [Hh Hv]]".
       { iDestruct "Hh" as (sh) "(H● & %hdom & #Hh)".
         iDestruct (sem_heap_own_valid_2 with "H● H◯") as "#HΦ".
         iDestruct ("Hh" with "[//]") as (iFs) "[H H▷]".
@@ -399,7 +413,7 @@ Section proofs.
         fold_leibniz; subst.
         iSplitR; first done.
         iSplitL. { iExists _. iFrame. by iSplit. }
-        iAssert (interp_fields σi t (subst_ty σt <$> σ) (dom _ fields) ifields interp_type) with "[Hifields]" as "Hifields_t".
+        iAssert (interp_fields t (subst_ty σt <$> σ) (dom _ fields) ifields (interp_type Σc Σi)) with "[Hifields]" as "Hifields_t".
         { destruct wfΔ.
           by iApply interp_fields_inclusion.
         }
@@ -416,7 +430,7 @@ Section proofs.
       iNext.
       iFrame.
       destruct wfΔ.
-      assert (hsub: [] ⊢ subst_ty (subst_ty σt <$> σ) fty <: subst_ty targs fty).
+      assert (hsub: Σc ⊢ subst_ty (subst_ty σt <$> σ) fty <: subst_ty targs fty).
       { assert (hfwf := hf).
         apply has_field_wf in hfwf => //.
         apply has_field_mono in hf => //.
@@ -449,7 +463,7 @@ Section proofs.
       + iDestruct "Hle" as "[Hthis Hle]".
         simpl.
         iDestruct "Hthis" as (l' t1 σ0 σt fields ifields) "[%H [#Hfields #Hl]]".
-        destruct H as ([= <-] & hin & hwf & heq & hfields).
+        destruct H as ([= <-] & hin & hwf & hok & heq & hfields).
         iExists l, t1, σ0, σt, fields, ifields.
         repeat iSplit => //.
         by inv H2.
@@ -473,14 +487,14 @@ Section proofs.
         by rewrite Hdom not_elem_of_dom.
       }
       set (iFs :=
-         (λ(ty: lang_ty), Next (interp_car (interp_type ty σi))) <$> ((λ x, subst_ty targs x.1.2) <$> fields)
+         (λ(ty: lang_ty), Next (interp_car (interp_type Σc Σi ty))) <$> ((λ x, subst_ty targs x.1.2) <$> fields)
       ).
       iMod ((sem_heap_own_update new) with "H●") as "[H● #H◯]" => //;
         first by apply (sem_heap_view_alloc _ new t iFs).
       iIntros "!> !>". (* kill the modalities *)
-      iAssert (interp_type (ClassT t targs) σi (LocV new)) with "[]" as "#Hl".
+      iAssert (interp_type Σc Σi (ClassT t targs) (LocV new)) with "[]" as "#Hl".
       {
-        iAssert (interp_fields σi t targs (dom _ fields) iFs interp_type) as "HiFs".
+        iAssert (interp_fields t targs (dom _ fields) iFs (interp_type Σc Σi)) as "HiFs".
         { rewrite /interp_fields; iSplit; first by rewrite /iFs !dom_fmap_L.
           iIntros (f vis fty orig) "%hfty".
           apply hf in hfty.
@@ -543,13 +557,13 @@ Section proofs.
       { rewrite (map_args_lookup _ _ _ args vargs H6 f) in hv0.
         by rewrite ha0 in hv0.
       }
-      assert (hty0: expr_has_ty [] lty a0 (subst_ty targs fty.1.2)) by (by apply harg with f).
+      assert (hty0: expr_has_ty Σc lty a0 (subst_ty targs fty.1.2)) by (by apply harg with f).
       rewrite !lookup_fmap hty /=  option_equivI later_equivI.
       iNext.
       rewrite discrete_fun_equivI.
       iSpecialize ("hiF" $! v0).
       iRewrite -"hiF".
-      iDestruct (expr_adequacy _ a0 with "Hle") as "#Ha0" => //; by apply wfΔ.
+      iDestruct (expr_adequacy Σc Σi a0 with "Hle") as "#Ha0" => //; by apply wfΔ.
     - (* CallC *) inv hc; simpl.
       destruct wfΔ.
       (* Get inherits relation between dynamic tag and static tag *)
@@ -563,10 +577,10 @@ Section proofs.
       rename H7 into hhasm0.
       rename H11 into heval_body.
       rename H12 into heval_ret.
-      iDestruct (expr_adequacy _ recv with "Hle") as "#Hrecv" => //.
+      iDestruct (expr_adequacy Σc Σi recv with "Hle") as "#Hrecv" => //.
       rewrite interp_class_unfold /=.
       iDestruct "Hrecv" as (? t1 def σin σt fields ifields) "[%Hpure [hifields Hl]]".
-      destruct Hpure as [[= <-] [hin_t1_t [hwf_t1_σt [hdef [htargs hfields]]]]].
+      destruct Hpure as ([= <-] & hin_t1_t & hwf_t1_σt & hok_t1_σt & hdef & htargs & hfields).
       iDestruct "Hh" as (sh) "(H● & %Hdom & #Hh)".
       iDestruct (sem_heap_own_valid_2 with "H● Hl") as "#HΦ".
       iDestruct ("Hh" with "[//]") as (?) "[H H▷]".
@@ -585,11 +599,16 @@ Section proofs.
         wf_extends_wf wf_override wf_parent wf_methods_bounded
         hin_t1_t hhasm0 hhasm)
       as (σoin & σot1 & σot & odef0 & odef & omdef0 & omdef &
-         hσeq & hodef0 & hodef & homdef0 & homdef & hin_o_o0 & hin_t1_o0 & hin_t_o &
+         hσeq & hodef0 & hodef & homdef0 & homdef & hin_o0_o & hin_t1_o0 & hin_t_o &
          -> & -> & hincl0 & hincl1).
       (* Get location of the definition of the dynamic method mdef0 *)
       destruct (has_method_from_def _ _ _ _  wf_parent wf_methods_bounded hhasm0) as
         (odef0' & mdef0_orig & hodef0' & hmdef0_orig & hhasm_morig0 & [σ0 [hin_t1_o0' heqmdef]]).
+      assert (hokσ0: Forall (ok_ty def1.(constraints)) σ0).
+      { apply inherits_using_ok in hin_t1_o0' => //.
+        destruct hin_t1_o0' as (? & ? & hok); simplify_eq.
+        by apply ok_ty_class_inv in hok.
+      }
       rewrite hodef0 in hodef0'; injection hodef0'; intros <-; clear hodef0'.
       rewrite homdef0 in hmdef0_orig; injection hmdef0_orig; intros <-; clear hmdef0_orig.
       replace σot1 with σ0 in *; last by eapply inherits_using_fun.
@@ -628,13 +647,18 @@ Section proofs.
         destruct hin_t1_o0 as (? & ? & ? & ? & ? & hL &?); simplify_eq.
         by rewrite hL.
       }
-      (* Get typing information about mdef0 *)
+      assert (hσ0: Forall wf_ty σ0) by by apply wf_ty_class_inv in wf0.
+      (* Get typing information about mdef0.
+       * To make the proof easier, we add all the constraints in the mix.
+       * However as we'll prove just after, Σc imply all the other,
+       * so we can only keep Σc in the end
+       *)
       assert (mdef0_wt:
         ∃ rty, wf_lty rty ∧
-        cmd_has_ty (subst_constraints σt (subst_constraints σ0 odef0.(constraints)))
+        cmd_has_ty (Σc ++ subst_constraints σt (def1.(constraints) ++ subst_constraints σ0 odef0.(constraints)))
                    (subst_lty σt {| type_of_this := (orig0, σ0); ctxt := subst_ty σ0 <$> methodargs omdef0 |})
                    (methodbody omdef0) rty ∧
-        expr_has_ty (subst_constraints σt (subst_constraints σ0 odef0.(constraints)))
+        expr_has_ty (Σc ++ subst_constraints σt (def1.(constraints) ++ subst_constraints σ0 odef0.(constraints)))
                     rty (methodret omdef0) (subst_ty σt (subst_ty σ0 (methodrettype omdef0)))).
       { assert (h0 := hodef0).
         assert (h1 := homdef0).
@@ -646,6 +670,23 @@ Section proofs.
         - apply subst_wf_lty => //.
           by apply subst_wf_lty.
         - apply cmd_has_ty_subst => //.
+          { assert (hodef0' := hodef0).
+            apply wf_constraints_wf in hodef0'.
+            rewrite /wf_cdef_constraints_wf Forall_forall in hodef0'.
+            rewrite Forall_forall /subst_constraints => c hc.
+            apply elem_of_app in hc as [hc | hc ].
+            + apply wf_constraints_wf in hdef1.
+              rewrite /wf_cdef_constraints_wf Forall_forall in hdef1.
+              by apply hdef1.
+            + apply elem_of_list_fmap_2 in hc as [c' [-> hc]].
+              apply wf_constraints_wf in hdef1.
+              rewrite /wf_cdef_constraints_wf Forall_forall in hdef1.
+              apply wf_constraints_wf in hodef0.
+              rewrite /wf_cdef_constraints_wf Forall_forall in hodef0.
+              move: (hodef0 c' hc).
+              rewrite /wf_constraint /subst_constraint /=.
+              case => h1 h2; split; by apply wf_ty_subst.
+          }
           { split => /=; first by rewrite /this_type.
             rewrite map_Forall_lookup => k tk.
             rewrite lookup_fmap_Some.
@@ -657,6 +698,11 @@ Section proofs.
             apply h2 in h1.
             by apply h1 in hk.
           } 
+          { inv hok_t1_σt.
+            rewrite Forall_forall => ty hin.
+            apply elem_of_list_lookup_1 in hin as [i hin].
+            by eauto.
+          }
           replace 
             {| type_of_this := (orig0, σ0); ctxt := subst_ty σ0 <$> methodargs omdef0 |}
           with
@@ -671,7 +717,7 @@ Section proofs.
             apply h2 in h1.
             by apply h1.
           }
-          apply cmd_has_ty_subst => //.
+          apply cmd_has_ty_subst => //; first by apply wf_constraints_wf in hodef0.
           split => /=.
           { rewrite /this_type /=.
             econstructor => //.
@@ -692,11 +738,11 @@ Section proofs.
             apply wf_methods_bounded in h2.
             apply h2 in h1.
             by apply h1 in hk.
-        - apply expr_has_ty_subst => //.
+        - apply expr_has_ty_subst => //; first by apply ok_ty_class_inv in hok_t1_σt.
           rewrite subst_ty_id // in hret0 => //; last by rewrite -hL.
           by apply expr_has_ty_subst => //.
       }
-      destruct mdef0_wt as (rty & wfrty & hbody & hret).
+      destruct mdef0_wt as (rty & wfrty & hbody_ & hret_).
       assert (wfbody:
         wf_lty (subst_lty σt {| type_of_this := (orig0, σ0); ctxt := subst_ty σ0 <$> methodargs omdef0 |})
       ).
@@ -706,9 +752,7 @@ Section proofs.
           + apply inherits_using_wf in hin_t1_o0 => //.
             destruct hin_t1_o0 as (? & ? & ? & ? & hF & hL & hwf); simplify_eq.
             by rewrite map_length hL.
-          + apply wf_ty_subst_map => //.
-            apply inherits_using_wf in hin_t1_o0 => //.
-            by repeat destruct hin_t1_o0 as [? hin_t1_o0].
+          + by apply wf_ty_subst_map.
         - rewrite map_Forall_lookup => k tk.
           rewrite lookup_fmap_Some.
           case => ty [<- ].
@@ -722,15 +766,52 @@ Section proofs.
           apply h2 in h1.
           by apply h1 in hk.
       }
+      assert (hconstraints:
+        ∀ i c,
+          subst_constraints σt
+            (constraints def1 ++ subst_constraints σ0 (constraints odef0)) !! i = Some c →
+          Σc ⊢ c.1 <: c.2).
+      { move => i c hin.
+        apply list_lookup_fmap_inv in hin as [c' [-> hin]].
+        apply lookup_app_Some in hin as [hin | [? hin]].
+        - inv hok_t1_σt; simplify_eq.
+          rewrite /subst_constraint /=.
+          by eauto.
+        - rewrite /subst_constraints in hin.
+          apply list_lookup_fmap_inv in hin as [c'' [-> hin]].
+          apply inherits_using_ok in hin_t1_o0 as (? & ? & hok) => //; simplify_eq.
+          destruct c'' as [c0 c1]; simpl in *.
+          inv hok; simplify_eq.
+          apply H4 in hin.
+          apply subtype_subst with (σ := σt) in hin => //.
+          apply subtype_weaken with (Γ' := (Σc ++ subst_constraints σt (constraints def1))) in hin => //;
+            last by set_solver.
+          apply subtype_constraint_elim in hin => //.
+          move => j c hj.
+          rewrite /subst_constraints in hj.
+          apply list_lookup_fmap_inv in hj as [c' [-> hj]].
+          rewrite /subst_constraint /=.
+          inv hok_t1_σt; simplify_eq.
+          by eauto.
+      }
+      assert (hbody:
+        cmd_has_ty Σc 
+                   (subst_lty σt {| type_of_this := (orig0, σ0); ctxt := subst_ty σ0 <$> methodargs omdef0 |})
+                   (methodbody omdef0) rty) by
+        by eapply cmd_has_ty_constraint_elim.
+      clear hbody_.
+      assert (hret:
+        expr_has_ty Σc rty (methodret omdef0) (subst_ty σt (subst_ty σ0 (methodrettype omdef0)))) by
+        by eapply expr_has_ty_constraint_elim.
+      clear hret_.
       iModIntro; iNext.
-      admit (*
-      iSpecialize ("IH" $! _ _ _ wfbody hbody σi _ _ _ heval_body); simpl.
+      iSpecialize ("IH" $! _ _ _ _ wfbody hΣc hbody Σi _ _ _ hΣi hΣcΣi heval_body); simpl.
       iDestruct ("IH" with "[Hh Hle H●]") as "Hstep".
       { iSplit.
         - iExists _; iFrame.
           iSplit; last done.
           by rewrite Hdom.
-        - iApply (interp_local_tys_list _ lty le) => //.
+        - iApply (interp_local_tys_list _ _ lty le) => //.
           + destruct hincl0 as [hdomincl _].
             rewrite !dom_fmap_L in hdomincl.
             rewrite !dom_fmap_L in hdom.
@@ -758,8 +839,23 @@ Section proofs.
                 apply wf_ty_subst; first by (by apply wf_ty_class_inv in wf0).
                 apply has_method_wf in hhasm_morig0 as [hargs _] => //.
                 by apply hargs in hx.
+              - apply wf_methods_ok in hodef0.
+                apply hodef0 in homdef0 as [hargs_ok _].
+                assert (hx_ := hx).
+                apply hargs_ok in hx_.
+                apply ok_ty_subst with (Γ' := def1.(constraints)) (σ := σ0) in hx_ => //; last first.
+                { apply has_method_wf in hhasm_morig0 as [hargs _] => //.
+                  by apply hargs in hx.
+                }
+                apply ok_ty_subst with (Γ' := Σc) (σ := σt) in hx_ => //; first last.
+                { by apply ok_ty_class_inv in hok_t1_σt. }
+                { apply wf_ty_subst; first by (by apply wf_ty_class_inv in wf0).
+                  apply has_method_wf in hhasm_morig0 as [hargs _] => //.
+                  by apply hargs in hx.
+                }
+                by apply ok_ty_constraint_elim in hx_.
               - (* step by step, using variance info *)
-                assert (hsub: subst_ty targs (subst_ty σot ty') <: subst_ty (subst_ty σt <$> σin) (subst_ty σot ty')).
+                assert (hsub: Σc ⊢ subst_ty targs (subst_ty σot ty') <: subst_ty (subst_ty σt <$> σin) (subst_ty σot ty')).
                 { apply subtype_lift with (neg_variance <$> generics def) => //.
                   - assert (hmono := hodef).
                     apply wf_methods_mono in hmono.
@@ -800,10 +896,17 @@ Section proofs.
                 eapply SubTrans; first by exact hsub.
                 rewrite -subst_ty_subst; last first.
                 { by apply bounded_subst with (length σot). }
-                apply subtype_subst => //.
-                eapply hincl1 with x.
-                * by rewrite /subst_mdef /= lookup_fmap hx /=.
-                * by rewrite /subst_mdef /= !lookup_fmap hty' /=.
+                assert (hh: subst_constraints σ0 (constraints odef0) ⊢  (subst_ty σin (subst_ty σot ty')) <: (subst_ty σ0 tx')).
+                { apply hincl1 with x.
+                  + by rewrite /subst_mdef /= lookup_fmap hx.
+                  + by rewrite /subst_mdef /= !lookup_fmap hty'. 
+                }
+                apply subtype_subst with (σ := σt) in hh => //.
+                apply subtype_weaken
+                  with (Γ' := (Σc ++ subst_constraints σt (def1.(constraints) ++ subst_constraints σ0 (odef0.(constraints)))))
+                  in hh => //;
+                  last by set_solver.
+                by apply subtype_constraint_elim in hh.
             }
             rewrite /subst_mdef /= !dom_fmap_L in hdom1.
             apply mk_is_Some in hx.
@@ -821,8 +924,8 @@ Section proofs.
       iIntros "[Hmodels Hle2]"; iFrame.
       iApply interp_local_tys_update; first by done.
       destruct hincl1 as [? [? hret1]].
-      assert (hsub: subst_ty (subst_ty σt <$> σ0) (methodrettype omdef0) <:
-                    subst_ty targs (subst_ty σot (methodrettype omdef))).
+      assert (hsub: Σc ⊢ subst_ty (subst_ty σt <$> σ0) (methodrettype omdef0) <:
+                         subst_ty targs (subst_ty σot (methodrettype omdef))).
       { eapply SubTrans; last first.
         - apply subtype_lift with (σ1 := subst_ty σt <$> σin) (vs0 := generics def) => //.
           + assert (hmono := hodef).
@@ -849,27 +952,33 @@ Section proofs.
             * apply wf_methods_wf in hodef.
               apply hodef in homdef.
               by apply homdef.
-        - rewrite -!subst_ty_subst //; first by apply subtype_subst.
-          apply bounded_subst with (length σot) => //.
-          apply inherits_using_wf in hin_t_o => //.
-          destruct hin_t_o as (? & ? & ? & ? & ? & hL & _).
-          simplify_eq.
-          assert (ho := hodef).
-          apply wf_methods_bounded in ho.
-          apply ho in homdef.
-          rewrite hL.
-          by apply homdef.
+        - rewrite -!subst_ty_subst //.
+          + apply wf_methods_ok in hodef0.
+            apply hodef0 in homdef0 as [_ hret_ok].
+            apply subtype_subst with (σ := σt) in hret1 => //.
+            apply subtype_weaken
+              with (Γ' := Σc ++ subst_constraints σt (def1.(constraints) ++ subst_constraints σ0 odef0.(constraints)))
+              in hret1 => //;
+              last by set_solver.
+            by apply subtype_constraint_elim in hret1.
+          + apply bounded_subst with (length σot) => //.
+            apply inherits_using_wf in hin_t_o => //.
+            destruct hin_t_o as (? & ? & ? & ? & ? & hL & _).
+            simplify_eq.
+            assert (ho := hodef).
+            apply wf_methods_bounded in ho.
+            apply ho in homdef.
+            rewrite hL.
+            by apply homdef.
       }
-      iDestruct (expr_adequacy _ (methodret omdef0) with "Hle2") as "#Hret" => //.
+      iDestruct (expr_adequacy Σc Σi (methodret omdef0) with "Hle2") as "#Hret" => //.
       iApply subtype_is_inclusion => //.
       + apply wf_ty_subst.
-       * apply wf_ty_subst_map => //.
-         by apply wf_ty_class_inv in wf0.
+       * by apply wf_ty_subst_map.
        * apply wf_methods_wf in hodef0.
          apply hodef0 in homdef0.
          by apply homdef0.
       + by rewrite -subst_ty_subst.
-             *).
     - (* Subtyping *) 
       destruct wfΔ.
       iIntros "H".
@@ -882,7 +991,7 @@ Section proofs.
         by apply _.
     - (* CondTagC *) inv hc; last first.
       { iIntros "[Hh H]".
-        iAssert (heap_models st'.2 ∗ interp_local_tys σi rty st'.1)%I with "[Hh H]" as "H".
+        iAssert (heap_models st'.2 ∗ interp_local_tys Σc Σi rty st'.1)%I with "[Hh H]" as "H".
         + iFrame.
           destruct wfΔ.
           iApply interp_local_tys_is_inclusion => //.
@@ -904,9 +1013,9 @@ Section proofs.
       iDestruct "Hle" as "[Hthis Hle]".
       iDestruct ("Hle" $! v with "[//]") as (?) "[%Hlev Hv]".
       rewrite Hlev in hl; simplify_eq.
-      iAssert (interp_type MixedT σi (LocV l)) as "Hmixed".
+      iAssert (interp_type Σc Σi MixedT (LocV l)) as "Hmixed".
       { destruct wfΔ.
-        assert (hsub : [] ⊢ tv <: MixedT) by apply SubMixed.
+        assert (hsub : Σc ⊢ tv <: MixedT) by apply SubMixed.
         iApply subtype_is_inclusion => //.
         by apply wflty in hv.
       }
@@ -919,8 +1028,8 @@ Section proofs.
       { iDestruct "Hbool" as "%Hbool"; by destruct Hbool. }
       iDestruct "Hl" as (exTag exσ) "[wfex Hl]".
       iDestruct "Hl" as (k rt def σ σt exfields ifields) "[%H [#Hfields #Hl]]".
-      destruct H as [[= <-] [hinherits' [hwf' [hdef [ heq' hfields']]]]].
-      iAssert (⌜t' = rt⌝ ∗ heap_models st.2 ∗ interp_type (ExT rt) σi (LocV l))%I with "[H]" as "[%heq [Hh #Hv2]]".
+      destruct H as ([= <-] & hinherits' & hwf' & hok & hdef & heq' & hfields').
+      iAssert (⌜t' = rt⌝ ∗ heap_models st.2 ∗ interp_type Σc Σi (ExT rt) (LocV l))%I with "[H]" as "[%heq [Hh #Hv2]]".
       { iDestruct "H" as (sh) "(H● & %hdom & #Hh)".
         iDestruct (sem_heap_own_valid_2 with "H● Hl") as "#HΦ".
         iDestruct ("Hh" with "[//]") as (iFs) "[H H▷]".
@@ -963,18 +1072,20 @@ Section proofs.
         by iApply inherits_is_ex_inclusion.
       }
       by iApply "Hle".
-  Admitted.
-  (* Qed. *)
+  Qed.
 
-  Lemma cmd_adequacy (env: interp_env) lty cmd lty' :
+  Lemma cmd_adequacy Σc Σi lty cmd lty' :
     wf_cdefs Δ →
     wf_lty lty →
-    cmd_has_ty [] lty cmd lty' →
+    Forall wf_constraint Σc →
+    interp_env_as_mixed Σc Σi →
+    Σinterp Σc Σi →
+    cmd_has_ty Σc lty cmd lty' →
     ∀ st st' n, cmd_eval st cmd st' n →
-    heap_models st.2 ∗ interp_local_tys env lty st.1 -∗ |=▷^n
-        heap_models st'.2 ∗ interp_local_tys env lty' st'.1.
+    heap_models st.2 ∗ interp_local_tys Σc Σi lty st.1 -∗ |=▷^n
+        heap_models st'.2 ∗ interp_local_tys Σc Σi lty' st'.1.
   Proof.
-    move => ?? hty ??? hc.
+    intros.
     by iApply cmd_adequacy_.
   Qed.
 
@@ -1012,7 +1123,7 @@ Lemma sem_heap_init
   `{PDC: ProgDefContext}
   `{!sem_heapGpreS Σ}:
   ∀ MainTag methods, Δ !! MainTag = Some (main_cdef MainTag methods) →
-  ⊢@{iPropI Σ} |==> ∃ _: sem_heapGS Σ, (heap_models (main_heap MainTag) ∗ interp_local_tys [] (main_lty MainTag) main_le).
+  ⊢@{iPropI Σ} |==> ∃ _: sem_heapGS Σ, (heap_models (main_heap MainTag) ∗ interp_local_tys [] [] (main_lty MainTag) main_le).
 Proof.
   move => MainTag methods hΔ.
   set (empty := ∅ : gmap loc (prodO tagO (gmapO string (laterO (sem_typeO Σ))))).
@@ -1039,6 +1150,7 @@ Proof.
       { iPureIntro.
         split => //.
         split; first by eapply InheritsRefl.
+        split; first by econstructor.
         split; first by econstructor.
         split => //.
         rewrite /main_cdef in hΔ.

--- a/theories/examples.v
+++ b/theories/examples.v
@@ -31,6 +31,7 @@ Definition ROBox := {|
   classname := "ROBox";
   superclass := None;
   generics := [Covariant];
+  constraints := [];
   classfields := {["$data" := (Private, GenT 0)]};
   classmethods := {["get" := Get]};
 |}.
@@ -54,6 +55,7 @@ Definition Box := {|
   classname := "Box";
   superclass := None;
   generics := [Invariant];
+  constraints := [];
   classfields := {["$data" := (Public, GenT 0)]};
   classmethods := {["set" := BoxSet; "get" := Get]};
 |}.
@@ -77,6 +79,7 @@ Definition IntBoxS := {|
   classname := "IntBoxS";
   superclass := Some ("Box", σ);
   generics := [];
+  constraints := [];
   classfields := ∅;
   classmethods := {["set" := IntBoxSSet]};
 |}.
@@ -116,6 +119,7 @@ Definition Main := {|
   classname := "Main";
   superclass := None;
   generics := [];
+  constraints := [];
   classfields := ∅;
   classmethods := {["entry_point" := EntryPoint]};
  |}.

--- a/theories/examples.v
+++ b/theories/examples.v
@@ -421,7 +421,7 @@ Proof.
       by rewrite lookup_insert_ne.
 Qed.
 
-Lemma wf_mdef_ty_Main: wf_mdef_ty [] "Main" (gen_targs 0) (gen_targs 0) EntryPoint.
+Lemma wf_mdef_ty_Main: wf_mdef_ty [] "Main" (gen_targs 0) EntryPoint.
 Proof.
   rewrite /wf_mdef_ty.
   exists (final_lty {| type_of_this := ("Main", gen_targs 0); ctxt := subst_ty (gen_targs 0) <$> methodargs EntryPoint|}).

--- a/theories/examples.v
+++ b/theories/examples.v
@@ -1052,11 +1052,48 @@ Proof.
   done.
 Qed.
 
+Lemma wf_constraints_wf : map_Forall (λ _cname, wf_cdef_constraints_wf) Δ.
+Proof.
+  rewrite map_Forall_lookup => c0 d0.
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_wf /= Forall_nil. }
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_wf /= Forall_nil. }
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_wf /= Forall_nil. }
+  rewrite lookup_singleton_Some.
+  case => [? <-].
+  by rewrite /wf_cdef_constraints_wf /= Forall_nil.
+Qed.
+
+  
+Lemma wf_constraints_bounded : map_Forall (λ _cname, wf_cdef_constraints_bounded) Δ.
+Proof.
+  rewrite map_Forall_lookup => c0 d0.
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_bounded /= Forall_nil. }
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_bounded /= Forall_nil. }
+  rewrite lookup_insert_Some.
+  case => [[? <-]|[?]].
+  { by rewrite /wf_cdef_constraints_bounded /= Forall_nil. }
+  rewrite lookup_singleton_Some.
+  case => [? <-].
+  by rewrite /wf_cdef_constraints_bounded /= Forall_nil.
+Qed.
+
 Lemma wf: wf_cdefs Δ.
 Proof.
   split.
   by apply wf_extends_wf.
   by apply wf_parent.
+  by apply wf_constraints_wf.
+  by apply wf_constraints_bounded.
   by apply wf_override.
   by apply wf_fields.
   by apply wf_fields_bounded.

--- a/theories/examples.v
+++ b/theories/examples.v
@@ -317,7 +317,7 @@ Definition final_lty lty : local_tys :=
   (<["$robox" := ClassT "ROBox" [IntT]]> lty)))).
 
 Lemma Main_ty lty :
-  cmd_has_ty lty ProgramBody (final_lty lty).
+  cmd_has_ty [] lty ProgramBody (final_lty lty).
 Proof.
   rewrite /final_lty /ProgramBody.
   eapply SeqTy.
@@ -410,7 +410,7 @@ Proof.
       by rewrite lookup_insert_ne.
 Qed.
 
-Lemma wf_mdef_ty_Main: wf_mdef_ty "Main" (gen_targs 0) (gen_targs 0) EntryPoint.
+Lemma wf_mdef_ty_Main: wf_mdef_ty [] "Main" (gen_targs 0) (gen_targs 0) EntryPoint.
 Proof.
   rewrite /wf_mdef_ty.
   exists (final_lty {| type_of_this := ("Main", gen_targs 0); ctxt := subst_ty (gen_targs 0) <$> methodargs EntryPoint|}).
@@ -1111,7 +1111,7 @@ Qed.
  *)
 Theorem int_adequacy cmd st lty n:
   cmd_eval (main_le, main_heap "Main") cmd st n →
-  cmd_has_ty (main_lty "Main") cmd lty →
+  cmd_has_ty [] (main_lty "Main") cmd lty →
   ∀ v, lty.(ctxt) !! v = Some IntT →
   ∃ z, st.1.(lenv) !! v = Some (IntV z).
 Proof.
@@ -1139,7 +1139,7 @@ Qed.
 
 Theorem class_adequacy cmd st lty n:
   cmd_eval (main_le, main_heap "Main") cmd st n →
-  cmd_has_ty (main_lty "Main") cmd lty →
+  cmd_has_ty [] (main_lty "Main") cmd lty →
   ∀ v T σ, lty.(ctxt) !! v = Some (ClassT T σ) →
   ∃ l Tdyn vs, st.1.(lenv) !! v = Some (LocV l) ∧
           st.2 !! l = Some (Tdyn, vs) ∧

--- a/theories/interp.v
+++ b/theories/interp.v
@@ -76,9 +76,9 @@ Section proofs.
   Notation γ := sem_heap_name.
 
   (* Helping the inference with this notation that hides Δ *)
-  Local Notation "s <: t" := (@subtype _ s t) (at level 70, no associativity).
-  Local Notation "lty <:< rty" := (@lty_sub _ lty rty) (at level 70, no associativity).
-  Local Notation "lts <: vs :> rts" := (@subtype_targs _ vs lts rts) (at level 70, vs at next level).
+  Local Notation "Γ ⊢ s <: t" := (@subtype _ Γ s t) (at level 70, s at next level, no associativity).
+  Local Notation "Γ ⊢ lts <: vs :> rts" := (@subtype_targs _ Γ vs lts rts) (at level 70, lts, vs at next level).
+  Local Notation "Γ ⊢ lty <:< rty" := (@lty_sub _ Γ lty rty) (lty at next level, at level 70, no associativity).
 
   (* now, let's interpret some types ! *)
 
@@ -129,7 +129,10 @@ Section proofs.
       λ (w : value),
       (∃ ℓ t cdef σ σt (fields: stringmap ((visibility * lang_ty) * tag)) (ifields: gmapO string (laterO (sem_typeO Σ))),
       ⌜w = LocV ℓ ∧ inherits_using t C σ ∧ wf_ty (ClassT t σt) ∧
-       Δ !! C = Some cdef ∧ (subst_ty σt <$> σ) <: cdef.(generics) :> σC ∧
+      (* TODO: fix this. I put [] just so the files compiles for now.
+       * Will need to update when adding more subtyping rules.
+       *)
+       Δ !! C = Some cdef ∧ [] ⊢ (subst_ty σt <$> σ) <: cdef.(generics) :> σC ∧
        has_fields t fields⌝ ∗
       interp_fields σi t σt (dom stringset fields) ifields rec ∗
       (ℓ ↦ (t, ifields)))%I
@@ -488,13 +491,14 @@ Section proofs.
     | _, _, _ => False%I
     end.
 
+  (* TODO: fix this *)
   (* Main meat for A <: B → [|A|] ⊆ [|B|] *)
   Theorem subtype_is_inclusion_aux A B:
     map_Forall (λ _cname, wf_cdef_fields) Δ →
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_mono) Δ →
-    A <: B →
+    [] ⊢ A <: B →
     ∀ (env: interp_env) v,
     wf_ty A →
     interp_type_pre interp_type A env v -∗
@@ -506,7 +510,7 @@ Section proofs.
     map_Forall (λ _cname, wf_cdef_mono) Δ →
     Forall wf_ty As →
     Forall wf_ty Bs →
-    As <:Vs:> Bs →
+    [] ⊢ As <:Vs:> Bs →
     ∀ (env: interp_env),
     True%I -∗ iForall3 (interp_variance env) Vs As Bs.
   Proof.
@@ -654,7 +658,7 @@ Section proofs.
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_mono) Δ →
-    ∀ A B, A <: B →
+    ∀ A B, [] ⊢ A <: B →
     ∀ (env: interp_env) v,
     wf_ty A →
     interp_type A env v -∗ interp_type B env v.
@@ -710,7 +714,7 @@ Section proofs.
     map_Forall (λ _ : string, wf_cdef_mono) Δ →
     wf_lty lty →
     Forall (λ (i: interp Σ), ∀ v, Persistent (i v)) σi →
-    lty <:< rty →
+    [] ⊢ lty <:< rty →
     interp_local_tys σi lty le -∗
     interp_local_tys σi rty le.
   Proof.

--- a/theories/interp.v
+++ b/theories/interp.v
@@ -82,8 +82,11 @@ Section proofs.
 
   (* now, let's interpret some types ! *)
 
-  (* Most interpretation functions are parametrized by Σi: tvar -> interp.
-   * This environment is here to interpret generic types.
+  (* Most interpretation functions are parametrized by Σi: tvar -> interp
+   * and Σc: list constraint.
+   * Σi is here to interpret generic types.
+   * Σc is there to put constraints on generic types.
+   *
    * We could only consider closed types and eagerly apply all top level
    * substitution, but this way makes things a bit more compositional.
    *)

--- a/theories/interp.v
+++ b/theories/interp.v
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *)
-From stdpp Require Import base strings gmap stringmap fin_maps natmap.
+From stdpp Require Import base strings gmap stringmap fin_maps natmap list.
 From iris.base_logic Require Import upred derived.
 From iris.base_logic.lib Require Import iprop own.
 From iris.algebra Require Import ofe cmra gmap_view.
@@ -82,7 +82,7 @@ Section proofs.
 
   (* now, let's interpret some types ! *)
 
-  (* Most interpretation functions are parametrized by σi: tvar -> interp.
+  (* Most interpretation functions are parametrized by Σi: tvar -> interp.
    * This environment is here to interpret generic types.
    * We could only consider closed types and eagerly apply all top level
    * substitution, but this way makes things a bit more compositional.
@@ -105,56 +105,52 @@ Section proofs.
   Definition interp_nothing : interp Σ :=
     Interp (λ (_: value), False%I).
 
-   Notation ty_interpO := (lang_ty -d> listO (interpO Σ) -n> interpO Σ).
+  Notation ty_interpO := (lang_ty -d> interpO Σ).
 
-   Lemma ty_interpO_ne : ∀ (rec: ty_interpO) ty, NonExpansive (rec ty).
-   Proof.
-     move => rec ty.
-     apply _.
-   Qed.
+  Variable Σc : list constraint.
+  Variable Σi : list (interp Σ).
 
   Definition interp_fields
-    (σi: list (interp Σ))
     (C: tag)
     σC
     (dom_fields: stringset)
     (ifields: gmapO string (laterO (sem_typeO Σ)))
     (rec: ty_interpO) : iProp Σ :=
     (⌜dom _ ifields = dom_fields⌝ ∗
-    (∀ f vis ty orig, ⌜has_field f C vis ty orig⌝ -∗ ifields !! f ≡ Some (Next (interp_car (rec (subst_ty σC ty) σi))))
+    (∀ f vis ty orig, ⌜has_field f C vis ty orig⌝ -∗ ifields !! f ≡ Some (Next (interp_car (rec (subst_ty σC ty)))))
     )%I.
 
-  Definition interp_class C σC (σi: list (interp Σ)) (rec : ty_interpO) : interp Σ :=
+  Definition interp_class C σC (rec : ty_interpO) : interp Σ :=
     Interp (
       λ (w : value),
       (∃ ℓ t cdef σ σt (fields: stringmap ((visibility * lang_ty) * tag)) (ifields: gmapO string (laterO (sem_typeO Σ))),
-      ⌜w = LocV ℓ ∧ inherits_using t C σ ∧ wf_ty (ClassT t σt) ∧
-      (* TODO: fix this. I put [] just so the files compiles for now.
-       * Will need to update when adding more subtyping rules.
-       *)
-       Δ !! C = Some cdef ∧ [] ⊢ (subst_ty σt <$> σ) <: cdef.(generics) :> σC ∧
+      ⌜w = LocV ℓ ∧ inherits_using t C σ ∧
+       wf_ty (ClassT t σt) ∧ ok_ty Σc (ClassT t σt) ∧
+       Δ !! C = Some cdef ∧ Σc ⊢ (subst_ty σt <$> σ) <: cdef.(generics) :> σC ∧
        has_fields t fields⌝ ∗
-      interp_fields σi t σt (dom stringset fields) ifields rec ∗
+      interp_fields t σt (dom stringset fields) ifields rec ∗
       (ℓ ↦ (t, ifields)))%I
     ).
 
-  Definition interp_class_strict C σC (σi: list (interp Σ)) (rec : ty_interpO) : interp Σ :=
+  Definition interp_class_strict C σC (rec : ty_interpO) : interp Σ :=
     Interp (
       λ (w : value),
       (∃ ℓ t σ σt (fields: stringmap ((visibility * lang_ty) * tag)) (ifields: gmapO string (laterO (sem_typeO Σ))),
-      ⌜w = LocV ℓ ∧ inherits_using t C σ ∧ wf_ty (ClassT t σt) ∧ (subst_ty σt <$> σ) = σC ∧
+      ⌜w = LocV ℓ ∧ inherits_using t C σ ∧
+       wf_ty (ClassT t σt) ∧ ok_ty Σc (ClassT t σt) ∧
+       (subst_ty σt <$> σ) = σC ∧
        has_fields t fields⌝ ∗
-      interp_fields σi t σt (dom stringset fields) ifields rec ∗
+      interp_fields t σt (dom stringset fields) ifields rec ∗
       (ℓ ↦ (t, ifields)))%I
     ).
 
-  Lemma interp_class_from_strict C σC (σi: list (interp Σ)) (rec: ty_interpO) v:
+  Lemma interp_class_from_strict C σC (rec: ty_interpO) v:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    interp_class_strict C σC σi rec v -∗ interp_class C σC σi rec v.
+    interp_class_strict C σC rec v -∗ interp_class C σC rec v.
   Proof.
     iIntros (hp) "H".
     iDestruct "H" as (??????) "[%hpure [Hfields Hl]]".
-    destruct hpure as (-> & hin & hwf & heqp & hfs).
+    destruct hpure as (-> & hin & hwf & hok & heqp & hfs).
     assert (hin' := hin).
     apply inherits_using_wf in hin' => //.
     destruct hin' as (? & def & ? & ? & ? & hL & ?).
@@ -169,22 +165,22 @@ Section proofs.
     by rewrite hL.
   Qed.
 
-  Definition interp_ex σi (cname: tag) (rec: ty_interpO): interp Σ :=
-    Interp (λ (w: value), (∃ σc, ⌜Forall wf_ty σc⌝ ∗ interp_class cname σc σi rec w)%I).
+  Definition interp_ex (cname: tag) (rec: ty_interpO): interp Σ :=
+    Interp (λ (w: value), (∃ σc, ⌜Forall wf_ty σc⌝ ∗ interp_class cname σc rec w)%I).
 
-  Definition interp_nonnull σi (rec : ty_interpO) : interp Σ :=
+  Definition interp_nonnull (rec : ty_interpO) : interp Σ :=
     Interp (
       λ (v : value),
       ((interp_int v) ∨
       (interp_bool v) ∨
-      (∃ t, interp_ex σi t rec v))%I
+      (∃ t, interp_ex t rec v))%I
     ).
 
-  Definition interp_mixed σi (rec: ty_interpO) : interp Σ :=
-    Interp (λ (v: value), (interp_nonnull σi rec v ∨ interp_null v)%I).
+  Definition interp_mixed (rec: ty_interpO) : interp Σ :=
+    Interp (λ (v: value), (interp_nonnull rec v ∨ interp_null v)%I).
 
-  Definition interp_generic (σi: list (interpO Σ)) (tv: nat) : interp Σ :=
-    default interp_nothing (σi !! tv).
+  Definition interp_generic (tv: nat) : interp Σ :=
+    default interp_nothing (Σi !! tv).
 
   (* we use a blend of Coq/Iris recursion, the
      Coq recursion lets us handle simple structural
@@ -192,7 +188,6 @@ Section proofs.
      the more complicated case of class types.
   *)
   Section interp_type_pre_rec.
-    Variable (σi: listO (interpO Σ)).
     Variable (rec: ty_interpO).
 
     Fixpoint go (typ: lang_ty) : interp Σ :=
@@ -200,93 +195,27 @@ Section proofs.
       | IntT => interp_int
       | BoolT => interp_bool
       | NothingT => interp_nothing
-      | MixedT => interp_mixed σi rec
-      | ClassT A σA => interp_class A σA σi rec
+      | MixedT => interp_mixed rec
+      | ClassT A σA => interp_class A σA rec
       | NullT => interp_null
-      | NonNullT => interp_nonnull σi rec
+      | NonNullT => interp_nonnull rec
       | UnionT A B => interp_union (go A) (go B)
       | InterT A B => interp_inter (go A) (go B)
-      | GenT n => interp_generic σi n
-      | ExT cname => interp_ex σi cname rec
+      | GenT n => interp_generic n
+      | ExT cname => interp_ex cname rec
       end.
   End interp_type_pre_rec.
 
-  Local Instance interp_class_ne cname σc (rec: ty_interpO) :
-    NonExpansive (λ σi, interp_class cname σc σi rec).
-  Proof.
-    move => n x y h.
-    rewrite /interp_class => v.
-    rewrite /interp_fun !interp_car_simpl.
-    do 15 f_equiv.
-    rewrite /interp_fields.
-    do 15 f_equiv.
-    by apply ty_interpO_ne.
-  Qed.
-
-  Local Instance interp_ex_ne cname (rec: ty_interpO) :
-    NonExpansive (λ σi, interp_ex σi cname rec).
-  Proof.
-    move => n x y h.
-    rewrite /interp_ex => v.
-    rewrite /interp_fun !interp_car_simpl.
-    do 3 f_equiv.
-    by apply interp_class_ne.
-  Qed.
-
-  Local Instance interp_nonnull_ne (rec: ty_interpO) :
-    NonExpansive (λ σi, interp_nonnull σi rec).
-  Proof.
-    move => n x y h.
-    rewrite /interp_nonnull => v.
-    rewrite /interp_fun !interp_car_simpl.
-    do 5 f_equiv.
-    by apply interp_ex_ne.
-  Qed.
-
-  Local Instance go_ne (rec: ty_interpO) (ty: lang_ty) :
-    NonExpansive (λ σi, go σi rec ty).
-  Proof.
-    induction ty as [ | | | | A σ hi | | | A B hA hB | A B hA hB | i | cname ] => /= n x y h.
-    - done.
-    - done.
-    - done.
-    - rewrite /interp_mixed => v.
-      rewrite /interp_fun !interp_car_simpl.
-      do 5 f_equiv.
-      by apply interp_ex_ne.
-    - by apply interp_class_ne.
-    - done.
-    - by apply interp_nonnull_ne.
-    - rewrite /interp_union => v.
-      rewrite /interp_fun !interp_car_simpl.
-      f_equiv.
-      + revert v; by apply hA.
-      + revert v; by apply hB.
-    - rewrite /interp_inter => v.
-      rewrite /interp_fun !interp_car_simpl.
-      f_equiv.
-      + revert v; by apply hA.
-      + revert v; by apply hB.
-    - rewrite /interp_generic => v.
-      assert (hl: length x = length y) by now apply Forall2_length in h.
-      elim : x y i h hl => [ | hd tl hi]; case => [ | hd' tl'] i h /= hl => //.
-      apply Forall2_cons in h as [hhd htl].
-      case: i hi => [ | i ] hi //=.
-      apply:  hi; first done.
-      by lia.
-    - by apply interp_ex_ne.
-  Qed.
-
   (* TODO: find a better name for go *)
   Definition interp_type_pre (rec : ty_interpO) : ty_interpO :=
-    λ (typ : lang_ty), λne (σi: listO (interpO Σ)), go σi rec typ.
+    λ (typ : lang_ty), go rec typ.
 
   Global Instance interp_type_pre_persistent (rec: ty_interpO) :
-    ∀ t σi v, Persistent (interp_type_pre rec t σi v).
-  Proof. by move => ???; apply _. Qed.
+    ∀ t v, Persistent (interp_type_pre rec t v).
+  Proof. by move => ??; apply _. Qed.
 
-  Global Instance interp_class_contractive cname σc σi:
-    Contractive (interp_class cname σc σi). 
+  Global Instance interp_class_contractive cname σc:
+    Contractive (interp_class cname σc). 
   Proof.
     rewrite /interp_class => n i1 i2 hdist v.
     rewrite /interp_fun !interp_car_simpl.
@@ -299,7 +228,7 @@ Section proofs.
     by f_equiv.
   Qed.
 
-  Global Instance interp_ex_contractive σi cname: Contractive (interp_ex σi cname).
+  Global Instance interp_ex_contractive cname: Contractive (interp_ex cname).
   Proof.
     rewrite /interp_ex => n i1 i2 hdist v.
     rewrite /interp_fun !interp_car_simpl.
@@ -307,7 +236,7 @@ Section proofs.
     by apply interp_class_contractive.
   Qed.
 
-  Global Instance interp_nonnull_contractive σi: Contractive (interp_nonnull σi).
+  Global Instance interp_nonnull_contractive: Contractive interp_nonnull.
   Proof.
     rewrite /interp_nonnull => n i1 i2 hdist v.
     rewrite /interp_fun !interp_car_simpl.
@@ -320,7 +249,7 @@ Section proofs.
    *)
   Local Instance interp_type_pre_contractive : Contractive interp_type_pre.
   Proof.
-    rewrite /interp_type_pre => n rec1 rec2 hdist ty σi /=.
+    rewrite /interp_type_pre => n rec1 rec2 hdist ty /=.
     induction ty
       as [ | | | | cname σ hi | | | A B hA hB | A B hA hB | i | cname ] => /=.
     - done.
@@ -344,43 +273,35 @@ Section proofs.
      can be (mutually) recursive) *)
   Definition interp_type := fixpoint interp_type_pre.
 
-  Record interp_env := InterpEnv {
-    interp_env_car :> list (interpO Σ);
-    interp_env_as_mixed:
-      Forall (λ (e: interp Σ), ∀ v, e v -∗ interp_mixed interp_env_car interp_type v) interp_env_car
-  }.
-
-  Definition interp_env_empty : interp_env := InterpEnv [] (Forall_nil_2 _).
-
   (* Helper lemmas to control unfolding of some definitions *)
-  Lemma interp_type_unfold (σi: list (interpO Σ)) (ty : lang_ty) (v : value) :
-    interp_type ty σi v ⊣⊢ interp_type_pre interp_type ty σi v.
+  Lemma interp_type_unfold (ty : lang_ty) (v : value) :
+    interp_type ty v ⊣⊢ interp_type_pre interp_type ty v.
   Proof.
     rewrite {1}/interp_type.
-    apply (fixpoint_unfold interp_type_pre ty σi v).
+    apply (fixpoint_unfold interp_type_pre ty v).
   Qed.
 
-  Lemma interp_ex_unfold σi t v:
-    interp_type (ExT t) σi v ⊣⊢ interp_ex σi t interp_type v.
+  Lemma interp_ex_unfold t v:
+    interp_type (ExT t) v ⊣⊢ interp_ex t interp_type v.
   Proof. by rewrite interp_type_unfold /= /interp_ex /=. Qed.
 
-  Lemma interp_nonnull_unfold σi v:
-    interp_type NonNullT σi v ⊣⊢
-      (interp_int v) ∨ (interp_bool v) ∨ (∃ t, interp_ex σi t interp_type v)%I.
+  Lemma interp_nonnull_unfold v:
+    interp_type NonNullT v ⊣⊢
+      (interp_int v) ∨ (interp_bool v) ∨ (∃ t, interp_ex t interp_type v)%I.
   Proof. by rewrite interp_type_unfold /= /interp_nonnull /=. Qed.
 
-  Lemma interp_mixed_unfold σi v:
-    interp_type MixedT σi v ⊣⊢ interp_nonnull σi interp_type v ∨ interp_null v.
+  Lemma interp_mixed_unfold v:
+    interp_type MixedT v ⊣⊢ interp_nonnull interp_type v ∨ interp_null v.
   Proof. by rewrite interp_type_unfold /interp_mixed /=. Qed.
 
-  Lemma interp_class_unfold σi A σA v:
-    interp_type (ClassT A σA) σi v ⊣⊢
-    interp_class A σA σi interp_type v.
+  Lemma interp_class_unfold A σA v:
+    interp_type (ClassT A σA) v ⊣⊢
+    interp_class A σA interp_type v.
   Proof. by rewrite interp_type_unfold. Qed.
 
-  Lemma interp_union_unfold σi A B v:
-    interp_type (UnionT A B) σi v ⊣⊢
-    interp_union (interp_type A σi) (interp_type B σi) v.
+  Lemma interp_union_unfold A B v:
+    interp_type (UnionT A B) v ⊣⊢
+    interp_union (interp_type A) (interp_type B) v.
   Proof.
     rewrite interp_type_unfold /=.
     iSplit; iIntros "[H | H]".
@@ -390,9 +311,9 @@ Section proofs.
     - iRight; by rewrite interp_type_unfold.
   Qed.
 
-  Lemma interp_inter_unfold σi A B v:
-    interp_type (InterT A B) σi v ⊣⊢
-    interp_inter (interp_type A σi) (interp_type B σi) v.
+  Lemma interp_inter_unfold A B v:
+    interp_type (InterT A B) v ⊣⊢
+    interp_inter (interp_type A) (interp_type B) v.
   Proof.
     rewrite interp_type_unfold /=.
     iSplit; iIntros "[HL HR]".
@@ -402,9 +323,9 @@ Section proofs.
 
   (* #hyp *)
   Global Instance interp_type_persistent :
-    ∀ t σi v, Persistent (interp_type t σi v).
+    ∀ t v, Persistent (interp_type t v).
   Proof.
-    move => t σi v.
+    move => t v.
     rewrite interp_type_unfold.
     by apply _.
   Qed.
@@ -418,15 +339,15 @@ Section proofs.
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_mono) Δ →
     ∀ A B σB, extends_using A B σB →
-    ∀ σi v σA, Forall wf_ty σA →
-    interp_type (ClassT A σA) σi v -∗
-    interp_type (ClassT B (subst_ty σA <$> σB)) σi v.
+    ∀ v σA, Forall wf_ty σA →
+    interp_type (ClassT A σA) v -∗
+    interp_type (ClassT B (subst_ty σA <$> σB)) v.
   Proof.
-    move => hwf hwfb hwp hmono A B σB hext σi v σA hwfσA.
+    move => hwf hwfb hwp hmono A B σB hext v σA hwfσA.
     rewrite !interp_type_unfold /=.
     iIntros "h".
     iDestruct "h" as (ℓ t adef σ σt fields ifields) "[%h [hsem hl]]".
-    destruct h as [-> [hin [hσwf [hadef [hσ hfields]]]]].
+    destruct h as (-> & hin & hσwf & hσok & hadef & hσ & hfields).
     destruct (extends_using_wf _ _ _ hwp hext) as (adef' & bdef & hadef' & hbdef & hF & hL & hwfσB).
     simplify_eq.
     assert (hwfσt : Forall wf_ty σt) by (by apply wf_ty_class_inv in hσwf).
@@ -441,6 +362,7 @@ Section proofs.
     { iPureIntro; split; first done.
       split.
       { by eapply inherits_using_trans; last by econstructor. }
+      split; first done.
       split; first done.
       split; first done.
       split; last done.
@@ -473,14 +395,14 @@ Section proofs.
     by iApply "hfields".
   Qed.
 
-  Definition interp_variance env v ty0 ty1 : iProp Σ :=
+  Definition interp_variance v ty0 ty1 : iProp Σ :=
     match v with
     | Invariant => ∀ w,
-        interp_type_pre interp_type ty0 env w ∗-∗ interp_type_pre interp_type ty1 env w
+        interp_type_pre interp_type ty0 w ∗-∗ interp_type_pre interp_type ty1 w
     | Covariant => ∀ w,
-        interp_type_pre interp_type ty0 env w -∗ interp_type_pre interp_type ty1 env w
+        interp_type_pre interp_type ty0 w -∗ interp_type_pre interp_type ty1 w
     | Contravariant => ∀ w,
-        interp_type_pre interp_type ty1 env w -∗ interp_type_pre interp_type ty0 env w
+        interp_type_pre interp_type ty1 w -∗ interp_type_pre interp_type ty0 w
     end.
 
   Fixpoint iForall3 {A B C : Type} (P : A → B → C → iProp Σ) 
@@ -491,182 +413,229 @@ Section proofs.
     | _, _, _ => False%I
     end.
 
-  (* TODO: fix this *)
-  (* Main meat for A <: B → [|A|] ⊆ [|B|] *)
-  Theorem subtype_is_inclusion_aux A B:
-    map_Forall (λ _cname, wf_cdef_fields) Δ →
-    map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
-    map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    map_Forall (λ _cname, wf_cdef_mono) Δ →
-    [] ⊢ A <: B →
-    ∀ (env: interp_env) v,
-    wf_ty A →
-    interp_type_pre interp_type A env v -∗
-    interp_type_pre interp_type B env v
-  with subtype_targs_is_inclusion_aux Vs As Bs:
-    map_Forall (λ _cname, wf_cdef_fields) Δ →
-    map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
-    map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    map_Forall (λ _cname, wf_cdef_mono) Δ →
-    Forall wf_ty As →
-    Forall wf_ty Bs →
-    [] ⊢ As <:Vs:> Bs →
-    ∀ (env: interp_env),
-    True%I -∗ iForall3 (interp_variance env) Vs As Bs.
-  Proof.
-    { move => ????.
-      destruct 1 as [A | A h | A σA B σB adef hΔ hlen hext
+  Definition interp_env_as_mixed :=
+    ∀ i (ϕi: interp Σ),  Σi !! i = Some ϕi → ∀ v,  ϕi v -∗ interp_mixed interp_type v.
+
+  Definition Σinterp :=
+    ∀ i c, Σc !! i = Some c → 
+    ∀ v, interp_type_pre interp_type c.1 v -∗ interp_type_pre interp_type c.2 v.
+
+  Definition interp_local_tys
+    (lty : local_tys) (le : local_env) : iProp Σ :=
+    interp_class_strict lty.(type_of_this).1 lty.(type_of_this).2 interp_type (LocV le.(vthis)) ∗
+    (∀ v ty, ⌜lty.(ctxt) !! v = Some ty⌝ -∗
+    ∃ val, ⌜le.(lenv) !! v = Some val⌝ ∗ interp_type ty val)%I.
+
+  Section inclusion.
+    Hypothesis Σcoherency : Σinterp.
+
+    Hypothesis wfΣc : Forall wf_constraint Σc.
+
+    Hypothesis wfΣi : interp_env_as_mixed.
+
+    (* Main meat for A <: B → [|A|] ⊆ [|B|] *)
+    Theorem subtype_is_inclusion_aux A B:
+      map_Forall (λ _cname, wf_cdef_fields) Δ →
+      map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
+      map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
+      map_Forall (λ _cname, wf_cdef_mono) Δ →
+      Σc ⊢ A <: B →
+      ∀ v,
+      wf_ty A →
+      interp_type_pre interp_type A v -∗
+      interp_type_pre interp_type B v
+      with subtype_targs_is_inclusion_aux Vs As Bs:
+      map_Forall (λ _cname, wf_cdef_fields) Δ →
+      map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
+      map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
+      map_Forall (λ _cname, wf_cdef_mono) Δ →
+      Forall wf_ty As →
+      Forall wf_ty Bs →
+      Σc ⊢ As <:Vs:> Bs →
+      True%I -∗ iForall3 interp_variance Vs As Bs.
+    Proof.
+      { move => ????.
+        destruct 1 as [A | A h | A σA B σB adef hΔ hlen hext
         | A def σ0 σ1 hΔ hwfσ σ | | | | A | A B h
         | A B h | A B C h0 h1 | A B | A B | A B C h0 h1 
-        | A | A B C h0 h1 ] => env v hwfA.
-      - rewrite /interp_mixed.
-        clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        elim: A v hwfA => //.
-        + move => v _; iIntros "h"; by repeat iLeft.
-        + move => v _; iIntros "h"; by iLeft; iRight; iLeft.
-        + move => v _; by rewrite /interp_nothing; iIntros "h".
-        + move => cname targs _ v hwf.
-          apply wf_ty_class_inv in hwf.
+        | A | A B C h0 h1 | A B hin] => v hwfA.
+        - rewrite /interp_mixed.
+          clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          elim: A v hwfA => //.
+          + move => v _; iIntros "h"; by repeat iLeft.
+          + move => v _; iIntros "h"; by iLeft; iRight; iLeft.
+          + move => v _; by rewrite /interp_nothing; iIntros "h".
+          + move => cname targs _ v hwf.
+            apply wf_ty_class_inv in hwf.
+            iIntros "h".
+            iLeft; iRight; iRight.
+            iExists cname, targs.
+            iSplitR; last done.
+            by iPureIntro.
+          + move => v _; iIntros "h"; by iRight.
+          + move => v _; by iIntros "h"; iLeft.
+          + move => s t hs ht v hwf.
+            inv hwf.
+            rewrite /interp_union.
+            iIntros "h".
+            iDestruct "h" as "[ h | h ]"; first by iApply hs.
+            by iApply ht.
+          + move => s t hs ht v hwf.
+            inv hwf.
+            rewrite /interp_inter.
+            iIntros "h".
+            iDestruct "h" as "[? _]"; by iApply hs.
+          + move => n v _.
+            rewrite /interp_generic.
+            iIntros "hv".
+            destruct (decide (n < length Σi)) as [hlt | hge].
+            * apply lookup_lt_is_Some_2 in hlt as [ϕ hϕ].
+              iApply wfΣi; last done.
+              by rewrite /= /interp_generic hϕ /=.
+            * rewrite /= /interp_generic lookup_ge_None_2 /=; last by apply not_lt.
+              done.
+          + move => cname v _;
+            rewrite /interp_ex.
+            iIntros "hv".
+            iDestruct "hv" as (targs) "hv".
+            iLeft; iRight; iRight.
+            by iExists _, _.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          rewrite /=.
+          by iIntros "H".
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          apply wf_ty_class_inv in hwfA.
+          rewrite -!interp_type_unfold; by iApply extends_using_is_inclusion.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
           iIntros "h".
-          iLeft; iRight; iRight.
-          iExists cname, targs.
+          iDestruct "h" as (l t adef Σin σt fields ifields) "[%hpure [#hifields #hl]]".
+          destruct hpure as (-> & hin & hwft & hokt & hadef & hsub & hfields).
+          iExists l, t, adef, Σin, σt, fields, ifields.
+          iSplitR; last by iSplit.
+          iPureIntro.
+          repeat split => //.
+          simplify_eq.
+          by eapply subtype_targs_trans.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          by rewrite /= /interp_mixed.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          iIntros "h"; by iLeft.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          iIntros "h"; by iRight; iLeft.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          iIntros "H".
+          iRight; iRight.
+          iExists A, targs.
           iSplitR; last done.
-          by iPureIntro.
-        + move => v _; iIntros "h"; by iRight.
-        + move => v _; by iIntros "h"; iLeft.
-        + move => s t hs ht v hwf.
-          inv hwf.
-          rewrite /interp_union.
-          iIntros "h".
-          iDestruct "h" as "[ h | h ]"; first by iApply hs.
-          by iApply ht.
-        + move => s t hs ht v hwf.
-          inv hwf.
-          rewrite /interp_inter.
-          iIntros "h".
-          iDestruct "h" as "[? _]"; by iApply hs.
-        + move => n v _.
-          rewrite /interp_generic.
-          iIntros "hv".
-          destruct env as [env henv] => /=.
-          rewrite Forall_forall in henv.
-          destruct (decide (n < length env)) as [hlt | hge].
-          * iApply henv; last done.
-            apply lookup_lt_is_Some_2 in hlt as [ t ht ].
-            rewrite /interp_generic ht /=.
-            by apply elem_of_list_lookup_2 in ht.
-          * rewrite /interp_generic lookup_ge_None_2 /=; last by apply not_lt.
-            done.
-        + move => cname v _;
-          rewrite /interp_ex.
-          iIntros "hv".
-          iDestruct "hv" as (targs) "hv".
-          iLeft; iRight; iRight.
-          by iExists _, _.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        rewrite /=.
-        by iIntros "H".
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        apply wf_ty_class_inv in hwfA.
-        rewrite -!interp_type_unfold; by iApply extends_using_is_inclusion.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "h".
-        iDestruct "h" as (l t adef σin σt fields ifields) "[%hpure [#hifields #hl]]".
-        destruct hpure as (-> & hin & hwft & hadef & hsub & hfields).
-        iExists l, t, adef, σin, σt, fields, ifields.
-        iSplitR; last by iSplit.
-        iPureIntro.
-        repeat split => //.
-        simplify_eq.
-        by eapply subtype_targs_trans.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        by rewrite /= /interp_mixed.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "h"; by iLeft.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "h"; by iRight; iLeft.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "H".
-        iRight; iRight.
-        iExists A, targs.
-        iSplitR; last done.
-        iPureIntro.
-        by apply wf_ty_class_inv in hwfA.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        by iIntros "h"; iLeft.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        by iIntros "h"; iRight.
-      - rewrite /interp_union.
-        iIntros "[h | h]".
-        + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | | ].
-          * inv hwfA; by assumption.
-          * by iAssumption.
-        + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | | ].
-          * inv hwfA; by assumption.
-          * by iAssumption.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "[h _]".
-        by iAssumption.
-      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-        iIntros "[_ ?]".
-        by iAssumption.
-      - iIntros "h".
-        iSplit.
-        + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | done | ].
+          iPureIntro.
+          by apply wf_ty_class_inv in hwfA.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          by iIntros "h"; iLeft.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          by iIntros "h"; iRight.
+        - rewrite /interp_union.
+          iIntros "[h | h]".
+          + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | | ].
+            * inv hwfA; by assumption.
+            * by iAssumption.
+          + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | | ].
+            * inv hwfA; by assumption.
+            * by iAssumption.
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          iIntros "[h _]".
           by iAssumption.
-        + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | done | ].
+        - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+          iIntros "[_ ?]".
           by iAssumption.
-      - done.
-      - iIntros "h".
-        iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | | ].
-        + apply subtype_wf in h0; [ | done | done].
-          by assumption.
-        + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | done | ].
-          by iAssumption.
-    }
-    move => ???? hwfA hwfB.
-    destruct 1 as [ | ????? h0 h1 h | ????? h0 h | ????? h0 h]; iIntros (env) "_".
-    - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
-      done.
-    - simpl.
-      apply Forall_cons_1 in hwfA as [hA hwfA].
-      apply Forall_cons_1 in hwfB as [hB hwfB].
-      iSplitR.
-      + iIntros (w); iSplit.
-        * iApply subtype_is_inclusion_aux; by assumption.
-        * iApply subtype_is_inclusion_aux; by assumption.
-      + iApply subtype_targs_is_inclusion_aux; done.
-    - simpl.
-      apply Forall_cons_1 in hwfA as [hA hwfA].
-      apply Forall_cons_1 in hwfB as [hB hwfB].
-      iSplitR.
-      + iIntros (w).
-        iApply subtype_is_inclusion_aux; by assumption.
-      + iApply subtype_targs_is_inclusion_aux; done.
-    - simpl.
-      apply Forall_cons_1 in hwfA as [hA hwfA].
-      apply Forall_cons_1 in hwfB as [hB hwfB].
-      iSplitR.
-      + iIntros (w).
-        iApply subtype_is_inclusion_aux; by assumption.
-      + iApply subtype_targs_is_inclusion_aux; done.
-  Qed.
+        - iIntros "h".
+          iSplit.
+          + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | done | ].
+            by iAssumption.
+          + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | done | ].
+            by iAssumption.
+        - done.
+        - iIntros "h".
+          iApply subtype_is_inclusion_aux; [done | done | done | done | exact h1 | | ].
+          + apply subtype_wf in h0; [ | done | done | done ].
+            by assumption.
+          + iApply subtype_is_inclusion_aux; [done | done | done | done | exact h0 | done | ].
+            by iAssumption.
+        - apply elem_of_list_lookup_1 in hin as [i hin].
+          by apply Σcoherency in hin.
+      }
+      move => ???? hwfA hwfB.
+      destruct 1 as [ | ????? h0 h1 h | ????? h0 h | ????? h0 h]; iIntros "_".
+      - clear subtype_is_inclusion_aux subtype_targs_is_inclusion_aux.
+        done.
+      - simpl.
+        apply Forall_cons_1 in hwfA as [hA hwfA].
+        apply Forall_cons_1 in hwfB as [hB hwfB].
+        iSplitR.
+        + iIntros (w); iSplit.
+          * by iApply subtype_is_inclusion_aux.
+          * by iApply subtype_is_inclusion_aux.
+        + by iApply subtype_targs_is_inclusion_aux.
+      - simpl.
+        apply Forall_cons_1 in hwfA as [hA hwfA].
+        apply Forall_cons_1 in hwfB as [hB hwfB].
+        iSplitR.
+        + iIntros (w).
+          by iApply subtype_is_inclusion_aux.
+        + by iApply subtype_targs_is_inclusion_aux.
+      - simpl.
+        apply Forall_cons_1 in hwfA as [hA hwfA].
+        apply Forall_cons_1 in hwfB as [hB hwfB].
+        iSplitR.
+        + iIntros (w).
+          by iApply subtype_is_inclusion_aux.
+        + by iApply subtype_targs_is_inclusion_aux.
+    Qed.
 
-  (* A <: B → [|A|] ⊆ [|B|] *)
-  Theorem subtype_is_inclusion:
-    map_Forall (λ _cname, wf_cdef_fields) Δ →
-    map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
-    map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    map_Forall (λ _cname, wf_cdef_mono) Δ →
-    ∀ A B, [] ⊢ A <: B →
-    ∀ (env: interp_env) v,
-    wf_ty A →
-    interp_type A env v -∗ interp_type B env v.
-  Proof.
-    move => ???? A B hAB env v ?.
+    (* A <: B → [|A|] ⊆ [|B|] *)
+    Theorem subtype_is_inclusion:
+      map_Forall (λ _cname, wf_cdef_fields) Δ →
+      map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
+      map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
+      map_Forall (λ _cname, wf_cdef_mono) Δ →
+      ∀ A B, Σc ⊢ A <: B →
+      ∀ v,
+      wf_ty A →
+      interp_type A v -∗ interp_type B v.
+    Proof.
+      move => ???? A B hAB v ?.
     rewrite !interp_type_unfold.
     by iApply subtype_is_inclusion_aux.
-  Qed.
+    Qed.
+
+    Lemma interp_local_tys_is_inclusion lty rty le:
+      map_Forall (λ _cname, wf_cdef_fields) Δ →
+      map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
+      map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
+      map_Forall (λ _ : string, wf_cdef_mono) Δ →
+      wf_lty lty →
+      Forall (λ (i: interp Σ), ∀ v, Persistent (i v)) Σi →
+      Σc ⊢ lty <:< rty →
+      interp_local_tys lty le -∗
+      interp_local_tys rty le.
+    Proof.
+      move => ???? hlty hpers hsub; iIntros "[#Hthis Hle]".
+      destruct hsub as [hthis hsub].
+      assert (hthis2: type_of_this lty = type_of_this rty).
+      { rewrite /this_type in hthis.
+        rewrite (surjective_pairing (type_of_this lty))
+        (surjective_pairing (type_of_this rty)).
+        by case : hthis => -> ->.
+      }
+      rewrite hthis2.
+      iSplitR; first done.
+      iIntros (v ty) "%Hv".
+      apply hsub in Hv as (B & hB & hsubB).
+      iDestruct ("Hle" $! v B hB) as (val) "[%Hv' #H]".
+      iExists val; iSplitR; first done.
+      iApply subtype_is_inclusion => //.
+      by apply hlty in hB.
+    Qed.
+  End inclusion.
 
   (* Specialized version for existential types. Will help during the
    * proof of adequacy for runtime checks.
@@ -677,17 +646,16 @@ Section proofs.
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_mono) Δ →
     ∀ A B, inherits A B →
-    ∀ (env: interp_env),
-    ∀ v, interp_type (ExT A) env v -∗ interp_type (ExT B) env v.
+    ∀ v, interp_type (ExT A) v -∗ interp_type (ExT B) v.
   Proof.
     move => ?? hp ?.
-    induction 1 as [ x | x y z hxy hyz hi ] => // σi v.
+    induction 1 as [ x | x y z hxy hyz hi ] => // v.
     rewrite interp_ex_unfold.
     iIntros "H".
     iApply hi; clear hyz hi.
     iDestruct "H" as (σx) "[%hσx H]".
     inv hxy.
-    iAssert (interp_type (ClassT y (subst_ty σx <$> σB)) σi v) with "[H]" as "Hext".
+    iAssert (interp_type (ClassT y (subst_ty σx <$> σB)) v) with "[H]" as "Hext".
     { iApply extends_using_is_inclusion => //.
       - by econstructor.
       - by rewrite interp_class_unfold.
@@ -700,51 +668,16 @@ Section proofs.
     rewrite /wf_cdef_parent H0 in H.
     by repeat destruct H as [? H].
   Qed.
-
-  Definition interp_local_tys
-    σi (lty : local_tys) (le : local_env) : iProp Σ :=
-    interp_class_strict lty.(type_of_this).1 lty.(type_of_this).2 σi interp_type (LocV le.(vthis)) ∗
-    (∀ v ty, ⌜lty.(ctxt) !! v = Some ty⌝ -∗
-    ∃ val, ⌜le.(lenv) !! v = Some val⌝ ∗ interp_type ty σi val)%I.
-
-  Lemma interp_local_tys_is_inclusion (σi: interp_env)  lty rty le:
-    map_Forall (λ _cname, wf_cdef_fields) Δ →
-    map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
-    map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    map_Forall (λ _ : string, wf_cdef_mono) Δ →
-    wf_lty lty →
-    Forall (λ (i: interp Σ), ∀ v, Persistent (i v)) σi →
-    [] ⊢ lty <:< rty →
-    interp_local_tys σi lty le -∗
-    interp_local_tys σi rty le.
-  Proof.
-    move => ???? hlty hpers hsub; iIntros "[#Hthis Hle]".
-    destruct hsub as [hthis hsub].
-    assert (hthis2: type_of_this lty = type_of_this rty).
-    { rewrite /this_type in hthis.
-      rewrite (surjective_pairing (type_of_this lty))
-              (surjective_pairing (type_of_this rty)).
-      by case : hthis => -> ->.
-    }
-    rewrite hthis2.
-    iSplitR; first done.
-    iIntros (v ty) "%Hv".
-    apply hsub in Hv as (B & hB & hsubB).
-    iDestruct ("Hle" $! v B hB) as (val) "[%Hv' #H]".
-    iExists val; iSplitR; first done.
-    iApply subtype_is_inclusion => //.
-    by apply hlty in hB.
-  Qed.
-
+  
   (* Helper to lift the conclusions of interp_class into a super class *)
-  Lemma interp_fields_inclusion σi t σt fields ifields σ C rec:
+  Lemma interp_fields_inclusion t σt fields ifields σ C rec:
     wf_no_cycle Δ →
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     map_Forall (λ _cname, wf_cdef_fields) Δ →
     map_Forall (λ _cname, wf_cdef_fields_bounded) Δ →
     inherits_using t C σ →
-    interp_fields σi t σt fields ifields rec -∗
-    interp_fields σi C (subst_ty σt <$> σ) fields ifields rec.
+    interp_fields t σt fields ifields rec -∗
+    interp_fields C (subst_ty σt <$> σ) fields ifields rec.
   Proof.
     move => ??? hb hin.
     rewrite /interp_fields.

--- a/theories/lang.v
+++ b/theories/lang.v
@@ -360,6 +360,9 @@ Definition not_contra v :=
 
 Inductive visibility := Public | Private.
 
+(* S <: T *)
+Definition constraint := (lang_ty * lang_ty)%type.
+
 Record classDef := {
   classname: tag;
   (* variance of the generics *)
@@ -367,7 +370,7 @@ Record classDef := {
   (* sets of constraints. All generics in this set must be bound
    * by the `generics` list above.
    *)
-  constraints : list (lang_ty * lang_ty);
+  constraints : list constraint;
   superclass: option (tag * list lang_ty);
   classfields : stringmap (visibility * lang_ty);
   classmethods : stringmap methodDef;

--- a/theories/lang.v
+++ b/theories/lang.v
@@ -362,7 +362,12 @@ Inductive visibility := Public | Private.
 
 Record classDef := {
   classname: tag;
-  generics: list variance; (* variance of the generics *)
+  (* variance of the generics *)
+  generics: list variance;
+  (* sets of constraints. All generics in this set must be bound
+   * by the `generics` list above.
+   *)
+  constraints : list (lang_ty * lang_ty);
   superclass: option (tag * list lang_ty);
   classfields : stringmap (visibility * lang_ty);
   classmethods : stringmap methodDef;

--- a/theories/lang.v
+++ b/theories/lang.v
@@ -8,12 +8,6 @@ From stdpp Require Import base strings gmap stringmap fin_maps.
 (* Not using iris but importing their ssreflect dependencies *)
 From iris.proofmode Require Import tactics.
 
-(* TODO:
- * - maybe update definitions of bounded and gen_targs to take
- *   a variance list or a class definition as input, and some
- *   of the details away.
- *)
-
 (* Helper tactics *)
 Ltac inv H := inversion H; subst; clear H.
 
@@ -362,6 +356,8 @@ Inductive visibility := Public | Private.
 
 (* S <: T *)
 Definition constraint := (lang_ty * lang_ty)%type.
+
+Definition bounded_constraint n c := bounded n c.1 ∧ bounded n c.2.
 
 Record classDef := {
   classname: tag;

--- a/theories/progdef.v
+++ b/theories/progdef.v
@@ -108,12 +108,13 @@ Section ProgDef.
   (* All constraints in a class definition must be well-formed and bounded
    * by the class generics.
    *)
+  Definition wf_constraint c := wf_ty c.1 ∧ wf_ty c.2.
+
   Definition wf_cdef_constraints_wf cdef :=
-    Forall (λ lu, wf_ty lu.1 ∧ wf_ty lu.2) cdef.(constraints).
+    Forall wf_constraint cdef.(constraints).
 
   Definition wf_cdef_constraints_bounded cdef :=
-    Forall (λ lu, bounded (length cdef.(generics)) lu.1 ∧
-                  bounded (length cdef.(generics)) lu.2) cdef.(constraints).
+    Forall (bounded_constraint (length cdef.(generics))) cdef.(constraints).
 
   (* A class definition 'parent' information is valid
    * if the parent class actually exists, and the subsitution is:

--- a/theories/progdef.v
+++ b/theories/progdef.v
@@ -105,6 +105,16 @@ Section ProgDef.
     by constructor.
   Qed.
 
+  (* All constraints in a class definition must be well-formed and bounded
+   * by the class generics.
+   *)
+  Definition wf_cdef_constraints_wf cdef :=
+    Forall (λ lu, wf_ty lu.1 ∧ wf_ty lu.2) cdef.(constraints).
+
+  Definition wf_cdef_constraints_bounded cdef :=
+    Forall (λ lu, bounded (length cdef.(generics)) lu.1 ∧
+                  bounded (length cdef.(generics)) lu.2) cdef.(constraints).
+
   (* A class definition 'parent' information is valid
    * if the parent class actually exists, and the subsitution is:
    * - of the right length (must capture all generics of the parent class)

--- a/theories/subtype.v
+++ b/theories/subtype.v
@@ -118,6 +118,53 @@ Section Subtype.
         by eapply subtype_targs_weaken.
   Qed.
 
+  Lemma subtype_constraint_elim_ G S T:
+    G ⊢ S <: T →
+    ∀ Γ Γ', G = Γ ++ Γ' →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ S <: T
+  with subtype_targs_constraint_elim_ G lhs vs rhs:
+    G ⊢ lhs <: vs :> rhs →
+    ∀ Γ Γ', G = Γ ++ Γ' →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ lhs <: vs :> rhs.
+  Proof.
+    - destruct 1 as [ ty | ty hwf | A σA B σB adef hadef hL hext
+      | A adef σ0 σ1 hadef hwf hσ | | | | A targs | s t ht | s t hs
+      | s t u hs ht | s t | s t | s t u hs ht | s | s t u hs ht | s t hin] => Γ Γ' heq hΓ; subst; try by econstructor.
+      + econstructor; [done | done | ].
+        by eapply subtype_targs_constraint_elim_.
+      + econstructor; by eapply subtype_constraint_elim_.
+      + econstructor; by eapply subtype_constraint_elim_.
+      + econstructor; by eapply subtype_constraint_elim_.
+      + apply elem_of_app in hin as [hin | hin].
+        { apply SubConstraint.
+          by set_solver.
+        }
+        apply elem_of_list_lookup_1 in hin as [i hin].
+        by apply hΓ in hin.
+    - destruct 1 as [ | ??????? h | ?????? h | ?????? h ] => Γ Γ' heq hΓ; subst.
+      + by constructor.
+      + econstructor; [ by eapply subtype_constraint_elim_ | by eapply subtype_constraint_elim_ | ].
+        by eapply subtype_targs_constraint_elim_.
+      + econstructor; [ by eapply subtype_constraint_elim_ | ].
+        by eapply subtype_targs_constraint_elim_.
+      + econstructor; [ by eapply subtype_constraint_elim_ | ].
+        by eapply subtype_targs_constraint_elim_.
+  Qed.
+
+  Lemma subtype_constraint_elim Γ Γ' S T:
+    Γ ++ Γ' ⊢ S <: T →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ S <: T.
+  Proof. intros; by eapply subtype_constraint_elim_. Qed.
+
+  Lemma subtype_targs_constraint_elim Γ Γ' lhs vs rhs:
+    Γ ++ Γ' ⊢ lhs <: vs :> rhs →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ lhs <: vs :> rhs.
+  Proof. intros; by eapply subtype_targs_constraint_elim_. Qed.
+
   Lemma subtype_constraint_trans Γ s t:
     Γ ⊢ s <: t →
     ∀ Γ', (∀ i c, Γ !! i = Some c → Γ' ⊢ c.1 <: c.2) →
@@ -877,6 +924,29 @@ Section Subtype.
     exists B; split; first assumption.
     by eapply subtype_weaken.
   Qed.
+
+  Lemma lty_sub_constraint_elim_ G lty rty:
+    G ⊢ lty <:< rty →
+    ∀ Γ Γ', G = Γ ++ Γ' →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ lty <:< rty.
+  Proof.
+    destruct lty as [this0 ctx0].
+    destruct rty as [this1 ctx1].
+    destruct 1 as [[= h0 h1] hctxt] => Γ Γ' heq hΓ; subst.
+    split; rewrite /this_type /=; first by rewrite h0 h1.
+    move => k A hA.
+    apply hctxt in hA as [B [hB hsub]]; simpl in *.
+    exists B; split => //.
+    by eapply subtype_constraint_elim.
+  Qed.
+
+  Lemma lty_sub_constraint_elim Γ Γ' lty rty:
+    (Γ ++ Γ') ⊢ lty <:< rty →
+    (∀ i c, Γ' !! i = Some c → Γ ⊢ c.1 <: c.2) →
+    Γ ⊢ lty <:< rty.
+  Proof. intros; by eapply lty_sub_constraint_elim_. Qed.
+
 
   Lemma lty_sub_reflexive Γ: reflexive _ (lty_sub Γ).
   Proof.

--- a/theories/subtype.v
+++ b/theories/subtype.v
@@ -16,63 +16,62 @@ Section Subtype.
   (* Type well-formdness is mostly introduced to be able to define
    * subtyping rule correctly, like unions.
    *)
-  Inductive subtype : lang_ty → lang_ty → Prop :=
-    | SubMixed : ∀ ty, subtype ty MixedT
-    | SubNothing : ∀ ty, wf_ty ty → subtype NothingT ty
-    | SubClass : ∀ A σA B σB adef,
+  Inductive subtype (Γ : list constraint) : lang_ty → lang_ty → Prop :=
+    | SubMixed: ∀ ty, subtype Γ ty MixedT
+    | SubNothing: ∀ ty, wf_ty ty → subtype Γ NothingT ty
+    | SubClass: ∀ A σA B σB adef,
         Δ !! A = Some adef →
         length σA = length (adef.(generics)) →
         extends_using A B σB →
-        subtype (ClassT A σA) (ClassT B (subst_ty σA <$> σB))
-    | SubVariance : ∀ A adef σ0 σ1,
+        subtype Γ (ClassT A σA) (ClassT B (subst_ty σA <$> σB))
+    | SubVariance: ∀ A adef σ0 σ1,
         Δ !! A = Some adef →
         Forall wf_ty σ1 →
-        subtype_targs adef.(generics) σ0 σ1 →
-        subtype (ClassT A σ0) (ClassT A σ1)
-    | SubMixed2: subtype MixedT (UnionT NonNullT NullT)
-    | SubIntNonNull: subtype IntT NonNullT
-    | SubBoolNonNull: subtype BoolT NonNullT
-    | SubClassNonNull: ∀ A targs, subtype (ClassT A targs) NonNullT
-    | SubUnionUpper1 : ∀ s t, wf_ty t → subtype s (UnionT s t)
-    | SubUnionUpper2 : ∀ s t, wf_ty s → subtype t (UnionT s t)
-        (* TODO: Do we need this one ? *)
-    | SubUnionLeast : ∀ s t u, subtype s u → subtype t u → subtype (UnionT s t) u
-    | SubInterLower1 : ∀ s t, subtype (InterT s t) s
-    | SubInterLower2 : ∀ s t, subtype (InterT s t) t
-    | SubInterGreatest: ∀ s t u, subtype u s → subtype u t → subtype u (InterT s t)
-    | SubRefl: ∀ s, subtype s s
-    | SubTrans : ∀ s t u, subtype s t → subtype t u → subtype s u
- with subtype_targs : list variance → list lang_ty → list lang_ty → Prop :=
-    | subtype_targs_nil : subtype_targs [] [] []
-    | subtype_targs_invariant : ∀ ty0 ty1 vs ty0s ty1s,
-        subtype ty0 ty1 →
-        subtype ty1 ty0 →
-        subtype_targs vs ty0s ty1s →
-        subtype_targs (Invariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
-    | subtype_targs_covariant : ∀ ty0 ty1 vs ty0s ty1s,
-        subtype ty0 ty1 →
-        subtype_targs vs ty0s ty1s →
-        subtype_targs (Covariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
-    | subtype_targs_contravariant : ∀ ty0 ty1 vs ty0s ty1s,
-        subtype ty1 ty0 →
-        subtype_targs vs ty0s ty1s →
-        subtype_targs (Contravariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
+        subtype_targs Γ adef.(generics) σ0 σ1 →
+        subtype Γ (ClassT A σ0) (ClassT A σ1)
+    | SubMixed2: subtype Γ MixedT (UnionT NonNullT NullT)
+    | SubIntNonNull: subtype Γ IntT NonNullT
+    | SubBoolNonNull: subtype Γ BoolT NonNullT
+    | SubClassNonNull: ∀ A targs, subtype Γ (ClassT A targs) NonNullT
+    | SubUnionUpper1: ∀ s t, wf_ty t → subtype Γ s (UnionT s t)
+    | SubUnionUpper2: ∀ s t, wf_ty s → subtype Γ t (UnionT s t)
+    | SubUnionLeast : ∀ s t u, subtype Γ s u → subtype Γ t u → subtype Γ (UnionT s t) u
+    | SubInterLower1: ∀ s t, subtype Γ (InterT s t) s
+    | SubInterLower2: ∀ s t, subtype Γ (InterT s t) t
+    | SubInterGreatest: ∀ s t u, subtype Γ u s → subtype Γ u t → subtype Γ u (InterT s t)
+    | SubRefl: ∀ s, subtype Γ s s
+    | SubTrans : ∀ s t u, subtype Γ s t → subtype Γ t u → subtype Γ s u
+  with subtype_targs (Γ: list constraint) : list variance → list lang_ty → list lang_ty → Prop :=
+    | subtype_targs_nil: subtype_targs Γ [] [] []
+    | subtype_targs_invariant: ∀ ty0 ty1 vs ty0s ty1s,
+        subtype Γ ty0 ty1 →
+        subtype Γ ty1 ty0 →
+        subtype_targs Γ vs ty0s ty1s →
+        subtype_targs Γ (Invariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
+    | subtype_targs_covariant: ∀ ty0 ty1 vs ty0s ty1s,
+        subtype Γ ty0 ty1 →
+        subtype_targs Γ vs ty0s ty1s →
+        subtype_targs Γ (Covariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
+    | subtype_targs_contravariant: ∀ ty0 ty1 vs ty0s ty1s,
+        subtype Γ ty1 ty0 →
+        subtype_targs Γ vs ty0s ty1s →
+        subtype_targs Γ (Contravariant :: vs) (ty0 :: ty0s) ( ty1 :: ty1s)
   .
  
-  Corollary length_subtype_targs_v0: ∀ vs ty0s ty1s,
-    subtype_targs vs ty0s ty1s → length vs = length ty0s.
+  Corollary length_subtype_targs_v0 Γ: ∀ vs ty0s ty1s,
+    subtype_targs Γ vs ty0s ty1s → length vs = length ty0s.
   Proof.
     induction 1 as [ | ??????? h hi | ?????? h hi | ?????? h hi] => //=; by rewrite hi.
   Qed.
 
-  Corollary length_subtype_targs_v1: ∀ vs ty0s ty1s,
-    subtype_targs vs ty0s ty1s → length vs = length ty1s.
+  Corollary length_subtype_targs_v1 Γ: ∀ vs ty0s ty1s,
+    subtype_targs Γ vs ty0s ty1s → length vs = length ty1s.
   Proof.
     induction 1 as [ | ??????? h hi | ?????? h hi | ?????? h hi] => //=; by rewrite hi.
   Qed.
 
-  Corollary length_subtype_targs_01: ∀ vs ty0s ty1s,
-    subtype_targs vs ty0s ty1s → length ty0s = length ty1s.
+  Corollary length_subtype_targs_01 Γ: ∀ vs ty0s ty1s,
+    subtype_targs Γ vs ty0s ty1s → length ty0s = length ty1s.
   Proof.
     induction 1 as [ | ??????? h hi | ?????? h hi | ?????? h hi] => //=; by rewrite hi.
   Qed.
@@ -80,11 +79,11 @@ Section Subtype.
   Hint Constructors subtype : core.
   Hint Constructors subtype_targs : core.
 
-  Notation "s <: t" := (subtype s t) (at level 70, no associativity).
-  Notation "lts <: vs :> rts" := (subtype_targs vs lts rts) (at level 70, vs at next level).
+  Notation "Γ ⊢ s <: t" := (subtype Γ s t) (at level 70, s at next level, no associativity).
+  Notation "Γ ⊢ lts <: vs :> rts" := (subtype_targs Γ vs lts rts) (at level 70, lts, vs at next level).
 
-  Lemma subtype_targs_refl vs: ∀ σ,
-    length vs = length σ → σ <:vs:> σ.
+  Lemma subtype_targs_refl Γ vs: ∀ σ,
+    length vs = length σ → Γ ⊢ σ <:vs:> σ.
   Proof.
     induction vs as [ | v vs hi] => σ hLen.
     - by rewrite (nil_length_inv σ).
@@ -94,8 +93,30 @@ Section Subtype.
       destruct v; by constructor.
   Qed.
 
-  Lemma neg_subtype_targs vs σ0 σ1 :
-    σ0 <:vs:> σ1 → σ1 <:(neg_variance <$> vs):> σ0.
+  Lemma subtype_weaken Γ s t: Γ ⊢ s <: t → ∀ Γ', Γ ⊆ Γ' → Γ' ⊢ s <: t
+   with subtype_targs_weaken Γ lhs vs rhs:
+     Γ ⊢ lhs <: vs :> rhs → ∀ Γ', Γ ⊆ Γ' → Γ' ⊢ lhs <: vs :> rhs.
+  Proof.
+    - destruct 1 as [ ty | ty hwf | A σA B σB adef hadef hL hext
+      | A adef σ0 σ1 hadef hwf hσ | | | | A targs | s t ht | s t hs
+      | s t u hs ht | s t | s t | s t u hs ht | s | s t u hs ht] => Γ' hΓ; try by econstructor.
+      + econstructor; [ done | done | ].
+        by eapply subtype_targs_weaken.
+      + econstructor; by eapply subtype_weaken.
+      + econstructor; by eapply subtype_weaken.
+      + econstructor; by eapply subtype_weaken.
+    - destruct 1 as [ | ??????? h | ?????? h | ?????? h ] => Γ' hΓ.
+      + by constructor.
+      + econstructor; [ by eapply subtype_weaken | by eapply subtype_weaken | ].
+        by eapply subtype_targs_weaken.
+      + econstructor; [ by eapply subtype_weaken | ].
+        by eapply subtype_targs_weaken.
+      + econstructor; [ by eapply subtype_weaken | ].
+        by eapply subtype_targs_weaken.
+  Qed.
+
+  Lemma neg_subtype_targs Γ vs σ0 σ1 :
+    Γ ⊢ σ0 <:vs:> σ1 → Γ ⊢ σ1 <:(neg_variance <$> vs):> σ0.
   Proof.
     induction 1 as [ | ??????? h hi | ?????? h hi | ?????? h hi] => //=.
     - by constructor.
@@ -328,18 +349,18 @@ Section Subtype.
             by destruct wi.
   Qed.
 
-  Definition check_variance v ty0 ty1 :=
+  Definition check_variance Γ v ty0 ty1 :=
     match v with
-    | Invariant => (ty0 <: ty1) ∧ (ty1 <: ty0)
-    | Covariant => ty0 <: ty1
-    | Contravariant => ty1 <: ty0
+    | Invariant => (Γ ⊢ ty0 <: ty1) ∧ (Γ ⊢ ty1 <: ty0)
+    | Covariant => Γ ⊢ ty0 <: ty1
+    | Contravariant => Γ ⊢ ty1 <: ty0
     end.
 
-  Lemma subtype_targs_lookup_0 vs σ0 σ1:
-    σ0 <:vs:> σ1 →
+  Lemma subtype_targs_lookup_0 Γ vs σ0 σ1:
+    Γ ⊢ σ0 <:vs:> σ1 →
     ∀ k ty0, σ0 !! k = Some ty0 →
     ∃ v ty1, vs !! k = Some v ∧ σ1 !! k = Some ty1 ∧
-    check_variance v ty0 ty1.
+    check_variance Γ v ty0 ty1.
   Proof.
     induction 1 as [ | ????? h0 h1 h hi | ????? h0 h hi | ????? h0 h hi] => k tk.
     - by rewrite lookup_nil.
@@ -363,11 +384,11 @@ Section Subtype.
         exists v, t2; by repeat split.
   Qed.
 
-  Lemma subtype_targs_lookup_1 vs σ0 σ1:
-    σ0 <:vs:> σ1 →
+  Lemma subtype_targs_lookup_1 Γ vs σ0 σ1:
+    Γ ⊢ σ0 <:vs:> σ1 →
     ∀ k ty1, σ1 !! k = Some ty1 →
     ∃ v ty0, vs !! k = Some v ∧ σ0 !! k = Some ty0 ∧
-    check_variance v ty0 ty1.
+    check_variance Γ v ty0 ty1.
   Proof.
     move => hsub k ty1 h1.
     destruct (σ0 !! k) as [ty0 | ] eqn:h0; last first.
@@ -385,11 +406,11 @@ Section Subtype.
     by repeat split.
   Qed.
 
-  Lemma subtype_targs_lookup_v vs σ0 σ1:
-    σ0 <:vs:> σ1 →
+  Lemma subtype_targs_lookup_v Γ vs σ0 σ1:
+    Γ ⊢ σ0 <:vs:> σ1 →
     ∀ k v, vs !! k = Some v →
     ∃ ty0 ty1, σ0 !! k = Some ty0 ∧ σ1 !! k = Some ty1 ∧
-    check_variance v ty0 ty1.
+    check_variance Γ v ty0 ty1.
   Proof.
     move => hsub k v hv.
     destruct (σ0 !! k) as [ty0 | ] eqn:h0; last first.
@@ -407,13 +428,13 @@ Section Subtype.
     by repeat split.
   Qed.
       
-  Lemma subtype_targs_forall vs σ0 σ1:
+  Lemma subtype_targs_forall Γ vs σ0 σ1:
     length σ0 = length vs →
     length σ1 = length vs →
     (∀ k v ty0 ty1,
          vs !! k = Some v → σ0 !! k = Some ty0 → σ1 !! k = Some ty1 → 
-         check_variance v ty0 ty1) →
-    σ0 <:vs:> σ1.
+         check_variance Γ v ty0 ty1) →
+    Γ ⊢ σ0 <:vs:> σ1.
   Proof.
     move : σ0 σ1.
     induction vs as [ | v vs hi] => σ0 σ1 h0 h1 h.
@@ -443,10 +464,10 @@ Section Subtype.
           by apply (h (S k) v ty2 ty3).
   Qed.
 
-  Lemma subtype_targs_cons v t0 t1 vs σ0 σ1:
-    check_variance v t0 t1 →
-    σ0 <:vs:> σ1 →
-    (t0::σ0) <:(v::vs):> (t1::σ1).
+  Lemma subtype_targs_cons Γ v t0 t1 vs σ0 σ1:
+    check_variance Γ v t0 t1 →
+    Γ ⊢ σ0 <:vs:> σ1 →
+    Γ ⊢ (t0::σ0) <:(v::vs):> (t1::σ1).
   Proof.
     rewrite /check_variance => hc hs.
     destruct v; constructor => //.
@@ -454,9 +475,9 @@ Section Subtype.
     - by destruct hc.
   Qed.
 
-  Lemma subtype_wf A B:
+  Lemma subtype_wf Γ A B:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    wf_ty A → A <: B → wf_ty B.
+    wf_ty A → Γ ⊢ A <: B → wf_ty B.
   Proof.
     move => hp hwf.
     induction 1 as [ ty | ty h | A σA B σB adef hΔ hA hext
@@ -492,16 +513,20 @@ Section Subtype.
     - by eauto.
   Qed.
 
-  Lemma subtype_subst A B:
+  Definition subst_constraint σ c := (subst_ty σ c.1, subst_ty σ c.2).
+  Definition subst_constraints σ (cs: list constraint) :=
+    subst_constraint σ <$> cs.
+
+  Lemma subtype_subst Γ A B:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    A <: B → ∀ σ,
+    Γ ⊢ A <: B → ∀ σ,
     Forall wf_ty σ →
-    (subst_ty σ A) <: (subst_ty σ B)
-  with subtype_targs_subst vs As Bs:
+    (subst_constraints σ Γ) ⊢ (subst_ty σ A) <: (subst_ty σ B)
+  with subtype_targs_subst Γ vs As Bs:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    As <:vs:> Bs → ∀ σ,
+    Γ ⊢ As <:vs:> Bs → ∀ σ,
     Forall wf_ty σ →
-    (subst_ty σ <$> As) <:vs:> (subst_ty σ <$> Bs).
+    (subst_constraints σ Γ) ⊢ (subst_ty σ <$> As) <:vs:> (subst_ty σ <$> Bs).
   Proof.
     - move => hp.
       destruct 1 as [ ty | ty h | A σA B σB adef hΔ hA hext
@@ -545,24 +570,24 @@ Section Subtype.
         * by apply subtype_targs_subst.
   Qed.
 
-  Lemma subtype_subst_class A B σA σB:
+  Lemma subtype_subst_class Γ A B σA σB:
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
-    ClassT A σA <: ClassT B σB → ∀ σ,
+    Γ ⊢ ClassT A σA <: ClassT B σB → ∀ σ,
     Forall wf_ty σ →
-    ClassT A (subst_ty σ <$> σA) <: ClassT B (subst_ty σ <$> σB).
+    subst_constraints σ Γ ⊢ ClassT A (subst_ty σ <$> σA) <: ClassT B (subst_ty σ <$> σB).
   Proof.
     move => ? hsub σ h.
     by apply subtype_subst with (σ := σ) in hsub.
   Qed.
 
-  Lemma subtype_lift vs ty :
+  Lemma subtype_lift Γ vs ty :
     mono vs ty →
     ∀ σ0 σ1,
     wf_ty ty →
     Forall wf_ty σ0 →
     Forall wf_ty σ1 →
-    σ0 <:vs:> σ1 →
-    subst_ty σ0 ty <: subst_ty σ1 ty.
+    Γ ⊢ σ0 <:vs:> σ1 →
+    Γ ⊢ subst_ty σ0 ty <: subst_ty σ1 ty.
   Proof.
     induction 1 as [ vs | vs | vs | vs | vs | vs
       | vs s t hs his ht hit
@@ -640,12 +665,12 @@ Section Subtype.
           by apply neg_subtype_targs.
   Qed.
 
-  Lemma subtype_targs_lift σ:
+  Lemma subtype_targs_lift Γ σ:
     ∀ vs σ0 σ1 ws,
     Forall wf_ty σ →
     Forall wf_ty σ0 →
     Forall wf_ty σ1 →
-    σ0 <:vs:> σ1 →
+    Γ ⊢ σ0 <:vs:> σ1 →
     length σ = length ws →
     (∀ i wi ti, ws !! i = Some wi →
                 σ !! i = Some ti →
@@ -655,7 +680,7 @@ Section Subtype.
                 σ !! i = Some ti →
                 not_cov wi →
                 mono (neg_variance <$> vs) ti) →
-    (subst_ty σ0 <$> σ) <:ws:> (subst_ty σ1 <$> σ)
+    Γ ⊢ (subst_ty σ0 <$> σ) <:ws:> (subst_ty σ1 <$> σ)
     .
   Proof.
     induction σ as [ | ty σ hi] => vs σ0 σ1 ws hwf hwf0 hwf1 h hlen hcov hcontra;
@@ -682,13 +707,13 @@ Section Subtype.
       by apply (hcontra (S i) wi ti).
   Qed.
 
-  Lemma subtype_targs_inv_0 vs σ ty0 σ0:
-    (ty0 :: σ0) <:vs:> σ →
+  Lemma subtype_targs_inv_0 Γ vs σ ty0 σ0:
+    Γ ⊢ (ty0 :: σ0) <:vs:> σ →
     ∃ w ws ty1 σ1,
     vs = w :: ws ∧
     σ = ty1 :: σ1 ∧
-    check_variance w ty0 ty1 ∧
-    σ0 <:ws:> σ1.
+    check_variance Γ w ty0 ty1 ∧
+    Γ ⊢ σ0 <:ws:> σ1.
   Proof.
     move => h; inv h.
     - by exists Invariant, vs0, ty2, ty1s.
@@ -696,13 +721,13 @@ Section Subtype.
     - by exists Contravariant, vs0, ty2, ty1s.
   Qed.
 
-  Lemma subtype_targs_inv_1 vs σ ty1 σ1:
-    σ <:vs:> (ty1 :: σ1) →
+  Lemma subtype_targs_inv_1 Γ vs σ ty1 σ1:
+    Γ ⊢ σ <:vs:> (ty1 :: σ1) →
     ∃ w ws ty0 σ0,
     vs = w :: ws ∧
     σ = ty0 :: σ0 ∧
-    check_variance w ty0 ty1 ∧
-    σ0 <:ws:> σ1.
+    check_variance Γ w ty0 ty1 ∧
+    Γ ⊢ σ0 <:ws:> σ1.
   Proof.
     move => h; inv h.
     - by exists Invariant, vs0, ty0, ty0s.
@@ -710,11 +735,11 @@ Section Subtype.
     - by exists Contravariant, vs0, ty0, ty0s.
   Qed.
 
-  Lemma subtype_targs_trans σ:
+  Lemma subtype_targs_trans Γ σ:
     ∀ vs σ0 σ1,
-    σ0 <:vs:> σ1 →
-    σ <:vs:> σ0 →
-    σ <:vs:> σ1.
+    Γ ⊢ σ0 <:vs:> σ1 →
+    Γ ⊢ σ <:vs:> σ0 →
+    Γ ⊢ σ <:vs:> σ1.
   Proof.
     induction σ as [ | ty σ hi] => vs σ0 σ1 h01 h0.
     - inv h0.
@@ -733,20 +758,20 @@ Section Subtype.
   Qed.
 
   (* Sanity checks: Some derived rules *)
-  Lemma subtype_union_comm : ∀ A B,
+  Lemma subtype_union_comm Γ: ∀ A B,
     wf_ty A → wf_ty B →
-    (UnionT A B) <: (UnionT B A).
+    Γ ⊢ (UnionT A B) <: (UnionT B A).
   Proof. by auto. Qed.
 
-  Lemma subtype_inter_comm : ∀ A B,
+  Lemma subtype_inter_comm Γ : ∀ A B,
     wf_ty A → wf_ty B →
-    (InterT A B) <: (InterT B A).
+    Γ ⊢ (InterT A B) <: (InterT B A).
   Proof. by auto. Qed.
 
-  Lemma subtype_union_assoc:
+  Lemma subtype_union_assoc Γ:
     ∀ A B C,
     wf_ty A → wf_ty B → wf_ty C →
-    (UnionT (UnionT A B) C) <: (UnionT A (UnionT B C)).
+    Γ ⊢ (UnionT (UnionT A B) C) <: (UnionT A (UnionT B C)).
   Proof.
     move => A B C wfA wfB wfC.
     apply SubUnionLeast; last by eauto.
@@ -755,19 +780,19 @@ Section Subtype.
     constructor; by eauto.
   Qed.
 
-  Lemma subtype_inter_assoc:
+  Lemma subtype_inter_assoc Γ:
     ∀ A B C, 
     wf_ty A → wf_ty B → wf_ty C →
-    (InterT (InterT A B) C) <: (InterT A (InterT B C)).
+    Γ ⊢ (InterT (InterT A B) C) <: (InterT A (InterT B C)).
   Proof. by eauto. Qed.
 
   (* Generalized version of SubClass to any inheritance sequence *)
-  Lemma subtype_inherits_using A B σ σA adef:
+  Lemma subtype_inherits_using Γ A B σ σA adef:
     map_Forall (λ _ : string, wf_cdef_parent Δ) Δ →
     Δ !! A = Some adef →
     length σA = length (adef.(generics)) →
     inherits_using A B σ →
-    ClassT A σA <: ClassT B (subst_ty σA <$> σ).
+    Γ ⊢ ClassT A σA <: ClassT B (subst_ty σA <$> σ).
   Proof.
     move => hp hA hl h.
     move : h σA adef hA hl.
@@ -796,19 +821,19 @@ Section Subtype.
     ClassT lty.(type_of_this).1 lty.(type_of_this).2.
 
   (* Subtype / Inclusion of typing contexts *)
-  Definition lty_sub (lty rty: local_tys) :=
+  Definition lty_sub Γ (lty rty: local_tys) :=
     this_type lty = this_type rty ∧
-    ∀ k A, rty.(ctxt) !! k = Some A → ∃ B, lty.(ctxt) !! k = Some B ∧ B <: A.
+    ∀ k A, rty.(ctxt) !! k = Some A → ∃ B, lty.(ctxt) !! k = Some B ∧ Γ ⊢ B <: A.
 
-  Notation "lty <:< rty" := (lty_sub lty rty) (at level 70, no associativity).
+  Notation "Γ ⊢ lty <:< rty" := (lty_sub Γ lty rty) (lty at next level, at level 70, no associativity).
 
-  Lemma lty_sub_reflexive: reflexive _ lty_sub.
+  Lemma lty_sub_reflexive Γ: reflexive _ (lty_sub Γ).
   Proof.
     move => [this lty]; split => // k A ->.
     by exists A.
   Qed.
 
-  Lemma lty_sub_transitive: transitive _ lty_sub.
+  Lemma lty_sub_transitive Γ: transitive _ (lty_sub Γ).
   Proof.
     move => [[t0 σ0] lty] [[t1 σ1] rty] [[t2 σ2] zty] [h0 hlr] [h1 hrz].
     move : h0 h1.
@@ -833,9 +858,9 @@ Section Subtype.
         ctxt := subst_ty σ <$> lty.(ctxt);
     |}.
 
-  Lemma lty_sub_insert_1 lhs ty lty0 lty1:
-    lty0 <:< lty1 →
-    <[lhs:=ty]> lty0 <:< <[lhs:=ty]> lty1.
+  Lemma lty_sub_insert_1 Γ lhs ty lty0 lty1:
+    Γ ⊢ lty0 <:< lty1 →
+    Γ ⊢ <[lhs:=ty]> lty0 <:< <[lhs:=ty]> lty1.
   Proof.
     move => [hthis h]; split => // x xty.
     rewrite lookup_insert_Some.
@@ -847,9 +872,9 @@ Section Subtype.
       by exists B.
   Qed.
 
-  Lemma lty_sub_insert_2 ty0 ty1 lhs lty:
-    ty0 <: ty1 →
-    <[lhs := ty0]>lty <:< <[lhs := ty1]> lty.
+  Lemma lty_sub_insert_2 Γ ty0 ty1 lhs lty:
+    Γ ⊢ ty0 <: ty1 →
+    Γ ⊢ <[lhs := ty0]>lty <:< <[lhs := ty1]> lty.
   Proof.
     move => hsub; split => // k ty.
     rewrite lookup_insert_Some.
@@ -858,10 +883,11 @@ Section Subtype.
     - exists ty; by rewrite lookup_insert_ne.
   Qed.
 
-  Lemma lty_sub_subst σ lty rty:
+  Lemma lty_sub_subst Γ σ lty rty:
     map_Forall (λ _ : string, wf_cdef_parent Δ) Δ →
     Forall wf_ty σ →
-    lty <:< rty → (subst_lty σ lty) <:< (subst_lty σ rty).
+    Γ ⊢ lty <:< rty →
+    subst_constraints σ Γ ⊢ (subst_lty σ lty) <:< (subst_lty σ rty).
   Proof.
     destruct lty as [[lt lσ] lty].
     destruct rty as [[rt rσ] rty].
@@ -883,20 +909,20 @@ Section Subtype.
    * - return type must be a subtype
    * - argument types must be a supertype
    *)
-  Definition mdef_incl sub super :=
+  Definition mdef_incl Γ sub super :=
     dom stringset sub.(methodargs) = dom _ super.(methodargs) ∧
     (∀ k A B, sub.(methodargs) !! k = Some A →
-    super.(methodargs) !! k = Some B → B <: A) ∧
-    sub.(methodrettype) <: super.(methodrettype).
+    super.(methodargs) !! k = Some B → Γ ⊢ B <: A) ∧
+    Γ ⊢ sub.(methodrettype) <: super.(methodrettype).
 
-  Lemma mdef_incl_reflexive: reflexive _ mdef_incl.
+  Lemma mdef_incl_reflexive Γ: reflexive _ (mdef_incl Γ).
   Proof.
     move => mdef; split; first done.
     split; last done.
     by move => k A B -> [] ->.
   Qed.
 
-  Lemma mdef_incl_transitive: transitive _ mdef_incl.
+  Lemma mdef_incl_transitive Γ: transitive _ (mdef_incl Γ).
   Proof.
     move => m0 m1 m2 [hdom1 [h1 ?]] [hdom2 [h2 ?]]; split; first by etransitivity.
     split; last by eauto.
@@ -914,11 +940,11 @@ Section Subtype.
     - by eapply h1.
   Qed.
 
-  Lemma mdef_incl_subst mdef0 mdef1 σ :
+  Lemma mdef_incl_subst Γ mdef0 mdef1 σ :
     map_Forall (λ _cname, wf_cdef_parent Δ) Δ →
     Forall wf_ty σ →
-    mdef_incl mdef0 mdef1 →
-    mdef_incl (subst_mdef σ mdef0) (subst_mdef σ mdef1).
+    mdef_incl Γ mdef0 mdef1 →
+    mdef_incl (subst_constraints σ Γ) (subst_mdef σ mdef0) (subst_mdef σ mdef1).
   Proof.
     move => hp hσ.
     rewrite /mdef_incl /subst_mdef /=.
@@ -940,7 +966,8 @@ Section Subtype.
     inherits_using A B σ →
     adef.(classmethods) !! m = Some mA →
     bdef.(classmethods) !! m = Some mB →
-    mdef_incl mA (subst_mdef σ mB).
+    (* TODO: Check this *)
+    mdef_incl adef.(constraints) mA (subst_mdef σ mB).
 
   (* Key lemma for adequacy of method call:
    * if A <: B and they both have a method m (from resp. origA, origB), then
@@ -966,8 +993,8 @@ Section Subtype.
       inherits_using B origB σB ∧
       mdefA = subst_mdef σA mA ∧
       mdefB = subst_mdef σB mB ∧
-      mdef_incl mA (subst_mdef σin mB) ∧
-      mdef_incl mdefA (subst_mdef σ mdefB).
+      mdef_incl oA.(constraints) mA (subst_mdef σin mB) ∧
+      mdef_incl (subst_constraints σA oA.(constraints)) mdefA (subst_mdef σ mdefB).
   Proof.
     move => hc ho hp hm hin hA hB.
     assert (hhA := hA).
@@ -1025,7 +1052,7 @@ Section Subtype.
       }
       assert (hh: inherits_using origA origB (subst_ty σ'' <$> σB))
         by (by eapply inherits_using_trans).
-      assert (hincl : mdef_incl oaorig (subst_mdef (subst_ty σ'' <$> σB) oborig))
+      assert (hincl : mdef_incl oadef.(constraints) oaorig (subst_mdef (subst_ty σ'' <$> σB) oborig))
         by (by eapply (ho origA origB) in hh).
       do 10 (split => //).
       rewrite -subst_mdef_mdef; last first.

--- a/theories/typing.v
+++ b/theories/typing.v
@@ -419,6 +419,8 @@ Section Typing.
   Record wf_cdefs (prog: stringmap classDef) := {
     wf_extends_wf : wf_no_cycle prog;
     wf_parent : map_Forall (λ _cname, wf_cdef_parent prog) prog;
+    wf_constraints_wf : map_Forall (λ _cname, wf_cdef_constraints_wf) prog;
+    wf_constraints_bounded : map_Forall (λ _cname, wf_cdef_constraints_bounded) prog;
     wf_override : wf_method_override prog;
     wf_fields : map_Forall (λ _cname, wf_cdef_fields) prog;
     wf_fields_bounded : map_Forall (λ _cname, wf_cdef_fields_bounded) prog;

--- a/theories/typing.v
+++ b/theories/typing.v
@@ -754,18 +754,18 @@ Section Typing.
    * method bodies must be well-formed under a generic substitution mapping
    * Ti -> Ti.
    *)
-  Definition wf_mdef_ty Γ tag σ σ' mdef :=
+  Definition wf_mdef_ty Γ tag σ mdef :=
     ∃ rty,
     wf_lty rty ∧
     cmd_has_ty Γ
-      {| type_of_this := (tag, σ); ctxt := subst_ty σ' <$> mdef.(methodargs) |}
+      {| type_of_this := (tag, σ); ctxt := subst_ty σ <$> mdef.(methodargs) |}
       mdef.(methodbody) rty ∧
-    expr_has_ty Γ rty mdef.(methodret) (subst_ty σ' mdef.(methodrettype))
+    expr_has_ty Γ rty mdef.(methodret) (subst_ty σ mdef.(methodrettype))
   .
 
   Definition cdef_wf_mdef_ty cname cdef :=
     let σ := gen_targs (length cdef.(generics)) in
-    map_Forall (λ _mname mdef, wf_mdef_ty cdef.(constraints) cname σ σ mdef) cdef.(classmethods)
+    map_Forall (λ _mname mdef, wf_mdef_ty cdef.(constraints) cname σ mdef) cdef.(classmethods)
   .
 
   (* Collection of all program invariant (at the source level):


### PR DESCRIPTION
Introducing generic constraints: each class can specify a set of constraints to further refine its generic.
For example, one can now write

```
type arraykey = int | string;
class Box<T> where T <: arraykey { ... }
```

So an instance of Box can only create with `T` that are subtypes of `arraykey`.